### PR TITLE
fix(redeem): forward full external API response to client

### DIFF
--- a/src/app/redeem/api/route.ts
+++ b/src/app/redeem/api/route.ts
@@ -40,10 +40,13 @@ export async function POST(req: NextRequest) {
     }),
   });
 
+  const data = await response.json().catch(() => ({
+    message: "Redemption failed",
+  }));
+
   if (!response.ok) {
-    const err = await response.json().catch(() => ({ message: "Redemption failed" }));
-    return NextResponse.json(err, { status: response.status });
+    return NextResponse.json(data, { status: response.status });
   }
 
-  return NextResponse.json({ success: true });
+  return NextResponse.json(data);
 }


### PR DESCRIPTION
Instead of discarding the response body and returning a static { success: true }, the route now passes through whatever the external API returns — both on success and on error.

https://claude.ai/code/session_01WwiqX3YkcXG38WNMMBjG6e