### PR TITLE
fix(redeem): surface actual external API error instead of generic fal…

### DIFF
--- a/src/app/redeem/api/route.ts
+++ b/src/app/redeem/api/route.ts
@@ -40,9 +40,18 @@ export async function POST(req: NextRequest) {
     }),
   });
 
-  const data = await response.json().catch(() => ({
-    message: "Redemption failed",
-  }));
+  const rawText = await response.text().catch(() => "");
+
+  let data: Record<string, unknown>;
+  try {
+    data = JSON.parse(rawText);
+  } catch {
+    // External API returned non-JSON — surface status and raw body for debugging
+    return NextResponse.json(
+      { message: `External API error (${response.status})`, raw: rawText },
+      { status: response.status || 502 }
+    );
+  }
 
   if (!response.ok) {
     return NextResponse.json(data, { status: response.status });


### PR DESCRIPTION
…lback

When the external API returns a non-JSON body, the raw response text and HTTP status are now forwarded so the real error is visible.

https://claude.ai/code/session_01WwiqX3YkcXG38WNMMBjG6e