### PR TITLE
Add /locale URL prefix routing and move switcher to footer

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,17 @@
 import type { Metadata } from "next";
 import { Inter, Syne, DM_Sans } from "next/font/google";
+import { cookies } from "next/headers";
 import "./globals.css";
 import Footer from "@/components/page/footer";
 import { SiteHeader } from "@/components/page/site-header";
 import { AnalyticsProvider } from "@/components/analytics-provider";
 import SessionProvider from "@/components/SessionProvider";
-import { LanguageProvider } from "@/lib/i18n/LanguageProvider";
+import {
+  LanguageProvider,
+  LOCALE_COOKIE,
+  isLocale,
+} from "@/lib/i18n/LanguageProvider";
+import { DEFAULT_LOCALE } from "@/lib/i18n/translations";
 
 const inter = Inter({ subsets: ["latin"] });
 const syne = Syne({
@@ -27,19 +33,23 @@ export const metadata: Metadata = {
     "Explore the exciting world of OnThePixel.net! Engage in thrilling minigames like Duels and BuildFFA. Dive into the pixelated fun today!",
 };
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const cookieStore = await cookies();
+  const stored = cookieStore.get(LOCALE_COOKIE)?.value;
+  const initialLocale = isLocale(stored) ? stored : DEFAULT_LOCALE;
+
   return (
-    <html lang="en">
+    <html lang={initialLocale}>
       <head>
         <script async src="https://analytics.intern.onthepixel.net/script.js" data-website-id="2362b4d0-3dea-4b1e-b3f8-86b0af3e4bd1"></script>
       </head>
       <body className={`${inter.className} ${syne.variable} ${dmSans.variable} scroll-smooth bg-gray-950`}>
         <SessionProvider>
-          <LanguageProvider>
+          <LanguageProvider initialLocale={initialLocale}>
             <AnalyticsProvider>
               <SiteHeader />
               <main>{children}</main>

--- a/src/components/page/LanguageSwitcher.tsx
+++ b/src/components/page/LanguageSwitcher.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { usePathname, useRouter } from "next/navigation";
 import { useLanguage } from "@/lib/i18n/LanguageProvider";
 import {
   Locale,
@@ -8,8 +9,32 @@ import {
 } from "@/lib/i18n/translations";
 import { cn } from "@/lib/utils";
 
+function stripLocalePrefix(pathname: string): string {
+  const segments = pathname.split("/").filter(Boolean);
+  if (
+    segments.length > 0 &&
+    (SUPPORTED_LOCALES as readonly string[]).includes(segments[0])
+  ) {
+    const rest = segments.slice(1).join("/");
+    return rest ? `/${rest}` : "/";
+  }
+  return pathname || "/";
+}
+
 export function LanguageSwitcher({ className }: { className?: string }) {
   const { locale, setLocale, t } = useLanguage();
+  const router = useRouter();
+  const pathname = usePathname();
+
+  const handleChange = (next: Locale) => {
+    if (next === locale) return;
+    setLocale(next);
+    const cleanPath = stripLocalePrefix(pathname || "/");
+    const target =
+      cleanPath === "/" ? `/${next}` : `/${next}${cleanPath}`;
+    router.push(target);
+    router.refresh();
+  };
 
   return (
     <label className={cn("relative inline-flex items-center", className)}>
@@ -17,8 +42,8 @@ export function LanguageSwitcher({ className }: { className?: string }) {
       <select
         aria-label={t.common.language}
         value={locale}
-        onChange={(e) => setLocale(e.target.value as Locale)}
-        className="cursor-pointer rounded-md border border-gray-700 bg-gray-950 px-2 py-1 text-xs font-medium text-foreground/80 hover:text-primary focus:outline-none focus:ring-1 focus:ring-primary"
+        onChange={(e) => handleChange(e.target.value as Locale)}
+        className="cursor-pointer rounded-md border border-gray-700 bg-gray-950 px-2 py-1 text-xs font-medium text-gray-400 hover:text-green-500 focus:outline-none focus:ring-1 focus:ring-green-500"
       >
         {SUPPORTED_LOCALES.map((loc) => (
           <option key={loc} value={loc}>

--- a/src/components/page/footer.tsx
+++ b/src/components/page/footer.tsx
@@ -3,6 +3,7 @@ import Link from "next/link";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 import CookieSettingsButton from "@/components/cookie-settings-button";
+import { LanguageSwitcher } from "@/components/page/LanguageSwitcher";
 import { useTranslations } from "@/lib/i18n/LanguageProvider";
 import {
   IconBrandX,
@@ -273,18 +274,21 @@ export default function Footer() {
             </Link>
           </div>
         </div>
-        <div className="mt-8 flex w-full flex-col items-center justify-between border-t border-slate-800 pt-8 md:flex-row">
+        <div className="mt-8 flex w-full flex-col items-center justify-between gap-4 border-t border-slate-800 pt-8 md:flex-row">
           <p className="mb-4 text-sm text-gray-400 md:mb-0">
             Copyright &copy; 2022-{new Date().getFullYear()} OnThePixel.net® -{" "}
             {t.footer.copyright}
             <CookieSettingsButton />
           </p>
-          <Button
-            onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
-            className="rounded-full bg-white px-6 py-2 font-semibold text-black transition-colors hover:bg-gray-200"
-          >
-            {t.footer.backToTop}
-          </Button>
+          <div className="flex items-center gap-4">
+            <LanguageSwitcher />
+            <Button
+              onClick={() => window.scrollTo({ top: 0, behavior: "smooth" })}
+              className="rounded-full bg-white px-6 py-2 font-semibold text-black transition-colors hover:bg-gray-200"
+            >
+              {t.footer.backToTop}
+            </Button>
+          </div>
         </div>
       </div>
     </footer>

--- a/src/components/page/mobile-nav.tsx
+++ b/src/components/page/mobile-nav.tsx
@@ -7,7 +7,6 @@ import { Menu } from "lucide-react";
 import Link, { LinkProps } from "next/link";
 import { useRouter } from "next/navigation";
 import { useTranslations } from "@/lib/i18n/LanguageProvider";
-import { LanguageSwitcher } from "./LanguageSwitcher";
 
 export function MobileNav() {
   const [open, setOpen] = useState(false);
@@ -46,9 +45,6 @@ export function MobileNav() {
           </MobileLink>
           <Link href="https://discord.onthepixel.net">{t.nav.discord}</Link>
           <Link href="https://x.com/onthepixelnet">{t.nav.twitter}</Link>
-          <div className="mt-3">
-            <LanguageSwitcher />
-          </div>
         </div>
       </SheetContent>
     </Sheet>

--- a/src/components/page/site-header.tsx
+++ b/src/components/page/site-header.tsx
@@ -3,7 +3,6 @@ import Link from "next/link";
 import { buttonVariants } from "@/components/ui/button";
 import { MainNav } from "./main-nav";
 import { MobileNav } from "./mobile-nav";
-import { LanguageSwitcher } from "./LanguageSwitcher";
 import { RiDiscordLine } from "react-icons/ri";
 
 export function SiteHeader() {
@@ -12,8 +11,7 @@ export function SiteHeader() {
       <div className="container flex h-14 max-w-screen-2xl items-center">
         <MainNav />
         <div className="flex flex-1 items-center justify-end space-x-2">
-          <nav className="flex items-center gap-2">
-            <LanguageSwitcher className="hidden sm:inline-flex" />
+          <nav className="flex items-center">
             <Link
               href="https://discord.com/invite/Dpx3eK9t3z"
               target="_blank"

--- a/src/lib/i18n/LanguageProvider.tsx
+++ b/src/lib/i18n/LanguageProvider.tsx
@@ -16,7 +16,9 @@ import {
   translations,
 } from "./translations";
 
+export const LOCALE_COOKIE = "otp.locale";
 const STORAGE_KEY = "otp.locale";
+const ONE_YEAR = 60 * 60 * 24 * 365;
 
 type LanguageContextValue = {
   locale: Locale;
@@ -26,12 +28,24 @@ type LanguageContextValue = {
 
 const LanguageContext = createContext<LanguageContextValue | null>(null);
 
-function isLocale(value: string | null | undefined): value is Locale {
+export function isLocale(value: string | null | undefined): value is Locale {
   return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
+
+function readCookieLocale(): Locale | null {
+  if (typeof document === "undefined") return null;
+  const match = document.cookie
+    .split("; ")
+    .find((c) => c.startsWith(`${LOCALE_COOKIE}=`));
+  if (!match) return null;
+  const value = decodeURIComponent(match.split("=")[1] ?? "");
+  return isLocale(value) ? value : null;
 }
 
 function detectInitialLocale(): Locale {
   if (typeof window === "undefined") return DEFAULT_LOCALE;
+  const cookieLocale = readCookieLocale();
+  if (cookieLocale) return cookieLocale;
   try {
     const stored = window.localStorage.getItem(STORAGE_KEY);
     if (isLocale(stored)) return stored;
@@ -43,12 +57,26 @@ function detectInitialLocale(): Locale {
   return DEFAULT_LOCALE;
 }
 
-export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [locale, setLocaleState] = useState<Locale>(DEFAULT_LOCALE);
+function writeCookieLocale(locale: Locale) {
+  if (typeof document === "undefined") return;
+  document.cookie = `${LOCALE_COOKIE}=${locale}; path=/; max-age=${ONE_YEAR}; samesite=lax`;
+}
+
+export function LanguageProvider({
+  children,
+  initialLocale,
+}: {
+  children: React.ReactNode;
+  initialLocale?: Locale;
+}) {
+  const [locale, setLocaleState] = useState<Locale>(
+    initialLocale ?? DEFAULT_LOCALE,
+  );
 
   useEffect(() => {
+    if (initialLocale) return;
     setLocaleState(detectInitialLocale());
-  }, []);
+  }, [initialLocale]);
 
   useEffect(() => {
     if (typeof document !== "undefined") {
@@ -58,6 +86,7 @@ export function LanguageProvider({ children }: { children: React.ReactNode }) {
 
   const setLocale = useCallback((next: Locale) => {
     setLocaleState(next);
+    writeCookieLocale(next);
     try {
       window.localStorage.setItem(STORAGE_KEY, next);
     } catch {

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,30 @@
+import { NextResponse, type NextRequest } from "next/server";
+import { SUPPORTED_LOCALES } from "@/lib/i18n/translations";
+
+const LOCALE_COOKIE = "otp.locale";
+const ONE_YEAR = 60 * 60 * 24 * 365;
+
+export function middleware(req: NextRequest) {
+  const { pathname } = req.nextUrl;
+  const segments = pathname.split("/");
+  const first = segments[1];
+
+  if ((SUPPORTED_LOCALES as readonly string[]).includes(first)) {
+    const url = req.nextUrl.clone();
+    const rest = segments.slice(2).join("/");
+    url.pathname = "/" + rest;
+    const res = NextResponse.rewrite(url);
+    res.cookies.set(LOCALE_COOKIE, first, {
+      path: "/",
+      maxAge: ONE_YEAR,
+      sameSite: "lax",
+    });
+    return res;
+  }
+
+  return NextResponse.next();
+}
+
+export const config = {
+  matcher: ["/((?!api|_next/static|_next/image|favicon.ico|.*\\..*).*)"],
+};


### PR DESCRIPTION
- middleware.ts rewrites /de/* and /en/* to /* and persists the choice in a cookie, so onthepixel.net/de/apply, /en/team, etc. are now valid URLs
- layout reads the cookie server-side so the initial render matches
- LanguageSwitcher moved out of header/mobile-nav into the footer; on change it navigates to the locale-prefixed version of the current path