### PR TITLE
Move isLocale/LOCALE_COOKIE to non-client i18n module

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -6,12 +6,12 @@ import Footer from "@/components/page/footer";
 import { SiteHeader } from "@/components/page/site-header";
 import { AnalyticsProvider } from "@/components/analytics-provider";
 import SessionProvider from "@/components/SessionProvider";
+import { LanguageProvider } from "@/lib/i18n/LanguageProvider";
 import {
-  LanguageProvider,
+  DEFAULT_LOCALE,
   LOCALE_COOKIE,
   isLocale,
-} from "@/lib/i18n/LanguageProvider";
-import { DEFAULT_LOCALE } from "@/lib/i18n/translations";
+} from "@/lib/i18n/translations";
 
 const inter = Inter({ subsets: ["latin"] });
 const syne = Syne({

--- a/src/lib/i18n/LanguageProvider.tsx
+++ b/src/lib/i18n/LanguageProvider.tsx
@@ -10,13 +10,13 @@ import {
 } from "react";
 import {
   DEFAULT_LOCALE,
+  isLocale,
   Locale,
-  SUPPORTED_LOCALES,
+  LOCALE_COOKIE,
   Translations,
   translations,
 } from "./translations";
 
-export const LOCALE_COOKIE = "otp.locale";
 const STORAGE_KEY = "otp.locale";
 const ONE_YEAR = 60 * 60 * 24 * 365;
 
@@ -27,10 +27,6 @@ type LanguageContextValue = {
 };
 
 const LanguageContext = createContext<LanguageContextValue | null>(null);
-
-export function isLocale(value: string | null | undefined): value is Locale {
-  return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
-}
 
 function readCookieLocale(): Locale | null {
   if (typeof document === "undefined") return null;

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -2,10 +2,16 @@ export const SUPPORTED_LOCALES = ["en", "de"] as const;
 export type Locale = (typeof SUPPORTED_LOCALES)[number];
 export const DEFAULT_LOCALE: Locale = "en";
 
+export const LOCALE_COOKIE = "otp.locale";
+
 export const LOCALE_LABELS: Record<Locale, string> = {
   en: "English",
   de: "Deutsch",
 };
+
+export function isLocale(value: string | null | undefined): value is Locale {
+  return !!value && (SUPPORTED_LOCALES as readonly string[]).includes(value);
+}
 
 export const translations = {
   en: {


### PR DESCRIPTION
Server components (root layout) cannot import functions from a "use client" file. Relocate the helper and cookie name into translations.ts so the server layout can read the locale cookie without crashing at runtime.