### PR TITLE
Wire News translations via embedded relation; show choice when missing

### DIFF
--- a/src/app/bedwars/page.tsx
+++ b/src/app/bedwars/page.tsx
@@ -1,163 +1,291 @@
 import TopPage from "@/components/page/top";
+import { getServerLocale } from "@/lib/i18n/server";
 
-export default function Page() {
+export default async function Page() {
+  const locale = await getServerLocale();
   return (
     <>
       <TopPage />
       <section className="bg-gray-950 pt-36 min-h-screen text-white">
         <div className="container mx-auto px-4 py-10">
-          <h1 className="text-2xl font-bold mb-5">BEDWARS</h1>
-          <p className="mb-8">
-            Protect your bed and destroy your enemies' beds! 
-            Fight in teams and conquer the arena in this strategic PvP game.
-          </p>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {/* Team Combat */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">⚔️</div>
-                <h2 className="text-xl font-bold mb-3">Team Combat</h2>
-                <p className="text-sm text-gray-300">
-                  Fight with your team against other players. Collect resources and buy better equipment!
-                </p>
-              </div>
-            </div>
-
-            {/* Bed Defense */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">🛏️</div>
-                <h2 className="text-xl font-bold mb-3">Bed Defense</h2>
-                <p className="text-sm text-gray-300">
-                  Protect your bed from enemies. Without your bed, you can't respawn anymore!
-                </p>
-              </div>
-            </div>
-
-            {/* Strategy */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">🧠</div>
-                <h2 className="text-xl font-bold mb-3">Strategy</h2>
-                <p className="text-sm text-gray-300">
-                  Plan your attacks, manage resources and work together with your team!
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Stats */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Game Information</h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="text-2xl font-bold text-green-400">16</div>
-                <div className="text-sm text-gray-400">Max Players</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-blue-400">10-20min</div>
-                <div className="text-sm text-gray-400">Round Length</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-purple-400">4</div>
-                <div className="text-sm text-gray-400">Teams</div>
-              </div>
-            </div>
-          </div>
-
-          {/* How to Play */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">How to Play</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-green-400 mb-2">Basic Rules</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Collect resources from generators</li>
-                  <li>• Buy weapons and blocks in the shop</li>
-                  <li>• Destroy other teams' beds</li>
-                  <li>• Eliminate all enemies to win</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-red-400 mb-2">Pro Tips</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Defend your bed with blocks</li>
-                  <li>• Upgrade your generators early</li>
-                  <li>• Communicate with your team</li>
-                  <li>• Control the middle for diamonds</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Features */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Features</h2>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div>
-                <h3 className="font-semibold text-blue-400 mb-2">Different Modes</h3>
-                <p className="text-sm text-gray-300">Solo, Duo and Squad modes for different team sizes</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-purple-400 mb-2">Upgrades</h3>
-                <p className="text-sm text-gray-300">Improve your equipment and abilities during the game</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-yellow-400 mb-2">Multiple Maps</h3>
-                <p className="text-sm text-gray-300">Play on unique maps with different layouts</p>
-              </div>
-            </div>
-          </div>
-
-          {/* Strategy Guide */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Winning Strategies</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-blue-400 mb-2">Early Game</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Collect resources quickly</li>
-                  <li>• Buy wool for bed protection</li>
-                  <li>• Upgrade your generators</li>
-                  <li>• Explore the middle for better resources</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-orange-400 mb-2">Late Game</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Plan coordinated team attacks</li>
-                  <li>• Use TNT for bed destruction</li>
-                  <li>• Control important areas</li>
-                  <li>• Prepare for the final battle</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Call to Action - Coming Soon */}
-          <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-orange-500">
-            <h2 
-              className="text-lg font-bold text-orange-500" 
-              style={{ color: "#ff8c00", textShadow: "0 0 10px #ff8c00" }}
-            >
-              Coming Soon!
-            </h2>
-            <p className="mt-2">
-              Bedwars.net is still under development! We're working hard to bring you the best 
-              Bedwars experience possible. Stay tuned for updates and the official launch!
-            </p>
-            <div className="mt-4 flex flex-wrap gap-3">
-              <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-orange-400">
-                bedwars.net - Coming Soon
-              </span>
-              <span className="inline-block bg-orange-600/20 rounded-md px-3 py-1 text-sm text-orange-300">
-                🚧 In Development
-              </span>
-            </div>
-          </div>
+          {locale === "de" ? <BedWarsDE /> : <BedWarsEN />}
         </div>
       </section>
     </>
   );
 }
+
+function BedWarsEN() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">BEDWARS</h1>
+      <p className="mb-8">
+        Protect your bed and destroy your enemies&apos; beds! Fight in teams and
+        conquer the arena in this strategic PvP game.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="⚔️" title="Team Combat">
+          Fight with your team against other players. Collect resources and buy
+          better equipment!
+        </Card>
+        <Card icon="🛏️" title="Bed Defense">
+          Protect your bed from enemies. Without your bed, you can&apos;t respawn
+          anymore!
+        </Card>
+        <Card icon="🧠" title="Strategy">
+          Plan your attacks, manage resources and work together with your team!
+        </Card>
+      </div>
+
+      <Panel title="Game Information" inner="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <Stat value="16" label="Max Players" />
+        <Stat value="10-20min" label="Round Length" />
+        <Stat value="4" label="Teams" />
+      </Panel>
+
+      <Panel title="How to Play">
+        <TwoColList
+          left={["Basic Rules", [
+            "Collect resources from generators",
+            "Buy weapons and blocks in the shop",
+            "Destroy other teams' beds",
+            "Eliminate all enemies to win",
+          ]]}
+          right={["Pro Tips", [
+            "Defend your bed with blocks",
+            "Upgrade your generators early",
+            "Communicate with your team",
+            "Control the middle for diamonds",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Different Modes", "Solo, Duo and Squad modes for different team sizes"],
+          ["Upgrades", "Improve your equipment and abilities during the game"],
+          ["Multiple Maps", "Play on unique maps with different layouts"],
+        ]} />
+      </Panel>
+
+      <Panel title="Winning Strategies">
+        <TwoColList
+          left={["Early Game", [
+            "Collect resources quickly",
+            "Buy wool for bed protection",
+            "Upgrade your generators",
+            "Explore the middle for better resources",
+          ]]}
+          right={["Late Game", [
+            "Plan coordinated team attacks",
+            "Use TNT for bed destruction",
+            "Control important areas",
+            "Prepare for the final battle",
+          ]]}
+        />
+      </Panel>
+
+      <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-orange-500">
+        <h2
+          className="text-lg font-bold text-orange-500"
+          style={{ color: "#ff8c00", textShadow: "0 0 10px #ff8c00" }}
+        >
+          Coming Soon!
+        </h2>
+        <p className="mt-2">
+          Bedwars.net is still under development! We&apos;re working hard to bring
+          you the best Bedwars experience possible. Stay tuned for updates and
+          the official launch!
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-orange-400">
+            bedwars.net - Coming Soon
+          </span>
+          <span className="inline-block bg-orange-600/20 rounded-md px-3 py-1 text-sm text-orange-300">
+            🚧 In Development
+          </span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function BedWarsDE() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">BEDWARS</h1>
+      <p className="mb-8">
+        Beschütze dein Bett und zerstöre die Betten deiner Gegner! Kämpfe im
+        Team und erobere die Arena in diesem strategischen PvP-Modus.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="⚔️" title="Team-Kampf">
+          Kämpfe mit deinem Team gegen andere Spieler. Sammle Ressourcen und
+          kaufe bessere Ausrüstung!
+        </Card>
+        <Card icon="🛏️" title="Bett-Verteidigung">
+          Beschütze dein Bett vor Gegnern. Ohne dein Bett kannst du nicht mehr
+          respawnen!
+        </Card>
+        <Card icon="🧠" title="Strategie">
+          Plane deine Angriffe, verwalte Ressourcen und arbeite mit deinem
+          Team zusammen!
+        </Card>
+      </div>
+
+      <Panel title="Spielinformationen" inner="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <Stat value="16" label="Max. Spieler" />
+        <Stat value="10–20 Min" label="Rundenlänge" />
+        <Stat value="4" label="Teams" />
+      </Panel>
+
+      <Panel title="So wird gespielt">
+        <TwoColList
+          left={["Grundregeln", [
+            "Sammle Ressourcen an den Generatoren",
+            "Kaufe Waffen und Blöcke im Shop",
+            "Zerstöre die Betten der anderen Teams",
+            "Schalte alle Gegner aus, um zu gewinnen",
+          ]]}
+          right={["Profi-Tipps", [
+            "Verteidige dein Bett mit Blöcken",
+            "Verbessere deine Generatoren früh",
+            "Kommuniziere mit deinem Team",
+            "Kontrolliere die Mitte für Diamanten",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Verschiedene Modi", "Solo-, Duo- und Squad-Modi für unterschiedliche Teamgrößen"],
+          ["Upgrades", "Verbessere deine Ausrüstung und Fähigkeiten während des Spiels"],
+          ["Mehrere Maps", "Spiele auf einzigartigen Maps mit unterschiedlichen Layouts"],
+        ]} />
+      </Panel>
+
+      <Panel title="Gewinn-Strategien">
+        <TwoColList
+          left={["Frühes Spiel", [
+            "Sammle schnell Ressourcen",
+            "Kaufe Wolle zum Schutz deines Bettes",
+            "Verbessere deine Generatoren",
+            "Erkunde die Mitte für bessere Ressourcen",
+          ]]}
+          right={["Spätes Spiel", [
+            "Plane koordinierte Team-Angriffe",
+            "Nutze TNT, um Betten zu zerstören",
+            "Kontrolliere wichtige Bereiche",
+            "Bereite dich auf den finalen Kampf vor",
+          ]]}
+        />
+      </Panel>
+
+      <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-orange-500">
+        <h2
+          className="text-lg font-bold text-orange-500"
+          style={{ color: "#ff8c00", textShadow: "0 0 10px #ff8c00" }}
+        >
+          Demnächst!
+        </h2>
+        <p className="mt-2">
+          Bedwars.net ist noch in Entwicklung! Wir arbeiten daran, dir das
+          bestmögliche BedWars-Erlebnis zu bieten. Bleib dran für Updates und
+          den offiziellen Start!
+        </p>
+        <div className="mt-4 flex flex-wrap gap-3">
+          <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-orange-400">
+            bedwars.net – Demnächst
+          </span>
+          <span className="inline-block bg-orange-600/20 rounded-md px-3 py-1 text-sm text-orange-300">
+            🚧 In Entwicklung
+          </span>
+        </div>
+      </div>
+    </>
+  );
+}
+
+function Card({ icon, title, children }: { icon: string; title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
+      <div className="p-5">
+        <div className="text-3xl mb-3">{icon}</div>
+        <h2 className="text-xl font-bold mb-3">{title}</h2>
+        <p className="text-sm text-gray-300">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Panel({
+  title,
+  children,
+  inner,
+}: {
+  title: string;
+  children: React.ReactNode;
+  inner?: string;
+}) {
+  return (
+    <div className="bg-white/10 rounded-lg p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4">{title}</h2>
+      {inner ? <div className={inner}>{children}</div> : children}
+    </div>
+  );
+}
+
+function Stat({ value, label }: { value: string; label: string }) {
+  return (
+    <div className="text-center">
+      <div className="text-2xl font-bold text-green-400">{value}</div>
+      <div className="text-sm text-gray-400">{label}</div>
+    </div>
+  );
+}
+
+function TwoColList({
+  left,
+  right,
+}: {
+  left: [string, string[]];
+  right: [string, string[]];
+}) {
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <div>
+        <h3 className="font-semibold text-green-400 mb-2">{left[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {left[1].map((line) => (
+            <li key={line}>• {line}</li>
+          ))}
+        </ul>
+      </div>
+      <div>
+        <h3 className="font-semibold text-red-400 mb-2">{right[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {right[1].map((line) => (
+            <li key={line}>• {line}</li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function FeatureGrid({ items }: { items: [string, string][] }) {
+  const colors = ["text-blue-400", "text-purple-400", "text-yellow-400"];
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      {items.map(([title, body], i) => (
+        <div key={title}>
+          <h3 className={`font-semibold mb-2 ${colors[i % colors.length]}`}>{title}</h3>
+          <p className="text-sm text-gray-300">{body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+

--- a/src/app/buildffa/page.tsx
+++ b/src/app/buildffa/page.tsx
@@ -1,164 +1,268 @@
 import TopPage from "@/components/page/top";
+import { getServerLocale } from "@/lib/i18n/server";
 
-export default function Page() {
+export default async function Page() {
+  const locale = await getServerLocale();
   return (
     <>
       <TopPage />
       <section className="bg-gray-950 pt-36">
         <div className="container mx-auto px-4 py-10">
-          <h1 className="text-2xl font-bold mb-5">BUILDFFA</h1>
-          <p className="mb-8">
-            Free-for-all combat with building! Fight other players and use blocks to your advantage. 
-            Endless rounds with kit changes, map rotations, and valuable item drops.
-          </p>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {/* Free-for-All Combat */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">⚔️</div>
-                <h2 className="text-xl font-bold mb-3">Free-for-All Combat</h2>
-                <p className="text-sm text-gray-300">
-                  Fight against all other players! Use your weapons and building skills to get kills and climb the leaderboard.
-                </p>
-              </div>
-            </div>
-
-            {/* Building with Blocks */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">🧱</div>
-                <h2 className="text-xl font-bold mb-3">Building with Blocks</h2>
-                <p className="text-sm text-gray-300">
-                  Place blocks to create bridges, walls, or traps. Blocks disappear after some time, keeping the map clean and fresh.
-                </p>
-              </div>
-            </div>
-
-            {/* Item Drops */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">📦</div>
-                <h2 className="text-xl font-bold mb-3">Item Drops</h2>
-                <p className="text-sm text-gray-300">
-                  Every minute, 2 items spawn at random locations. Fight for control of these power-ups to get the advantage!
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Stats */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Game Information</h2>
-            <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-              <div className="text-center">
-                <div className="text-2xl font-bold text-green-400">∞</div>
-                <div className="text-sm text-gray-400">Endless Rounds</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-blue-400">10min</div>
-                <div className="text-sm text-gray-400">Kit Changes</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-purple-400">10min</div>
-                <div className="text-sm text-gray-400">Map Changes</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-orange-400">1min</div>
-                <div className="text-sm text-gray-400">Item Drops</div>
-              </div>
-            </div>
-          </div>
-
-          {/* How to Play */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">How to Play</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-green-400 mb-2">Basic Gameplay</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Drop into the map and start fighting</li>
-                  <li>• Kill other players to increase your score</li>
-                  <li>• Use blocks to build bridges and defenses</li>
-                  <li>• Respawn automatically when you die</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-red-400 mb-2">Advanced Tips</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Blocks disappear after some time</li>
-                  <li>• Control the item spawn areas</li>
-                  <li>• Adapt when kits change every 10 minutes</li>
-                  <li>• Learn the map layouts</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Features */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Features</h2>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div>
-                <h3 className="font-semibold text-blue-400 mb-2">Endless Action</h3>
-                <p className="text-sm text-gray-300">No round limits - just continuous fighting and building</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-purple-400 mb-2">Killstreak Tracking</h3>
-                <p className="text-sm text-gray-300">Build up killstreaks and compete on the leaderboards</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-yellow-400 mb-2">Dynamic Maps</h3>
-                <p className="text-sm text-gray-300">Maps and kits change regularly to keep gameplay fresh</p>
-              </div>
-            </div>
-          </div>
-
-          {/* Item System */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Item Drop System</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-purple-400 mb-2">Drop Mechanics</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• 2 items drop every minute</li>
-                  <li>• 4 possible spawn locations per map</li>
-                  <li>• Different items have different chances</li>
-                  <li>• Fight others for the best items</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-orange-400 mb-2">Strategy</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Rare items give big advantages</li>
-                  <li>• Control spawn areas when possible</li>
-                  <li>• Time your pushes with item drops</li>
-                  <li>• Deny enemies access to power-ups</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Call to Action */}
-          <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-green-500">
-            <h2 
-              className="text-lg font-bold text-green-500" 
-              style={{ color: "#00de6d", textShadow: "0 0 10px #00de6d" }}
-            >
-              Ready to Fight?
-            </h2>
-            <p className="mt-2">
-              Jump into BuildFFA and experience non-stop PvP action with building! 
-              With changing kits, maps, and item drops, every fight is different.
-            </p>
-            <div className="mt-4">
-              <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-green-400">
-                play.buildffa.net
-              </span>
-            </div>
-          </div>
+          {locale === "de" ? <BuildFFADE /> : <BuildFFAEN />}
         </div>
       </section>
     </>
+  );
+}
+
+function BuildFFAEN() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">BUILDFFA</h1>
+      <p className="mb-8">
+        Free-for-all combat with building! Fight other players and use blocks to your advantage.
+        Endless rounds with kit changes, map rotations, and valuable item drops.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="⚔️" title="Free-for-All Combat">
+          Fight against all other players! Use your weapons and building skills to get kills and climb the leaderboard.
+        </Card>
+        <Card icon="🧱" title="Building with Blocks">
+          Place blocks to create bridges, walls, or traps. Blocks disappear after some time, keeping the map clean and fresh.
+        </Card>
+        <Card icon="📦" title="Item Drops">
+          Every minute, 2 items spawn at random locations. Fight for control of these power-ups to get the advantage!
+        </Card>
+      </div>
+
+      <Panel title="Game Information" inner="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Stat value="∞" label="Endless Rounds" color="text-green-400" />
+        <Stat value="10min" label="Kit Changes" color="text-blue-400" />
+        <Stat value="10min" label="Map Changes" color="text-purple-400" />
+        <Stat value="1min" label="Item Drops" color="text-orange-400" />
+      </Panel>
+
+      <Panel title="How to Play">
+        <TwoColList
+          left={["Basic Gameplay", [
+            "Drop into the map and start fighting",
+            "Kill other players to increase your score",
+            "Use blocks to build bridges and defenses",
+            "Respawn automatically when you die",
+          ]]}
+          right={["Advanced Tips", [
+            "Blocks disappear after some time",
+            "Control the item spawn areas",
+            "Adapt when kits change every 10 minutes",
+            "Learn the map layouts",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Endless Action", "No round limits - just continuous fighting and building"],
+          ["Killstreak Tracking", "Build up killstreaks and compete on the leaderboards"],
+          ["Dynamic Maps", "Maps and kits change regularly to keep gameplay fresh"],
+        ]} />
+      </Panel>
+
+      <Panel title="Item Drop System">
+        <TwoColList
+          left={["Drop Mechanics", [
+            "2 items drop every minute",
+            "4 possible spawn locations per map",
+            "Different items have different chances",
+            "Fight others for the best items",
+          ]]}
+          right={["Strategy", [
+            "Rare items give big advantages",
+            "Control spawn areas when possible",
+            "Time your pushes with item drops",
+            "Deny enemies access to power-ups",
+          ]]}
+        />
+      </Panel>
+
+      <CallToAction
+        title="Ready to Fight?"
+        text="Jump into BuildFFA and experience non-stop PvP action with building! With changing kits, maps, and item drops, every fight is different."
+      />
+    </>
+  );
+}
+
+function BuildFFADE() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">BUILDFFA</h1>
+      <p className="mb-8">
+        Free-for-All-Kämpfe mit Bauen! Kämpfe gegen andere Spieler und nutze Blöcke zu deinem Vorteil.
+        Endlose Runden mit Kit-Wechseln, Map-Rotationen und wertvollen Item-Drops.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="⚔️" title="Free-for-All-Kampf">
+          Kämpfe gegen alle anderen Spieler! Nutze deine Waffen und Bau-Fähigkeiten, um Kills zu erzielen und in der Bestenliste aufzusteigen.
+        </Card>
+        <Card icon="🧱" title="Bauen mit Blöcken">
+          Platziere Blöcke, um Brücken, Mauern oder Fallen zu bauen. Blöcke verschwinden nach einiger Zeit und halten die Map sauber.
+        </Card>
+        <Card icon="📦" title="Item-Drops">
+          Jede Minute spawnen 2 Items an zufälligen Orten. Kämpfe um die Kontrolle dieser Power-Ups, um dir einen Vorteil zu sichern!
+        </Card>
+      </div>
+
+      <Panel title="Spielinformationen" inner="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Stat value="∞" label="Endlose Runden" color="text-green-400" />
+        <Stat value="10 Min" label="Kit-Wechsel" color="text-blue-400" />
+        <Stat value="10 Min" label="Map-Wechsel" color="text-purple-400" />
+        <Stat value="1 Min" label="Item-Drops" color="text-orange-400" />
+      </Panel>
+
+      <Panel title="So wird gespielt">
+        <TwoColList
+          left={["Grundlegender Ablauf", [
+            "Spawne in die Map und beginne zu kämpfen",
+            "Töte andere Spieler, um deinen Punktestand zu erhöhen",
+            "Baue mit Blöcken Brücken und Verteidigungen",
+            "Du respawnst automatisch, wenn du stirbst",
+          ]]}
+          right={["Fortgeschrittene Tipps", [
+            "Blöcke verschwinden nach einiger Zeit",
+            "Kontrolliere die Item-Spawn-Bereiche",
+            "Passe dich an, wenn die Kits alle 10 Minuten wechseln",
+            "Lerne die Layouts der Maps",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Endlose Action", "Keine Rundenlimits — nur kontinuierliches Kämpfen und Bauen"],
+          ["Killstreak-Tracking", "Baue Killstreaks auf und tritt in den Bestenlisten an"],
+          ["Dynamische Maps", "Maps und Kits wechseln regelmäßig, damit das Spiel frisch bleibt"],
+        ]} />
+      </Panel>
+
+      <Panel title="Item-Drop-System">
+        <TwoColList
+          left={["Drop-Mechanik", [
+            "2 Items droppen jede Minute",
+            "4 mögliche Spawn-Orte pro Map",
+            "Unterschiedliche Items haben unterschiedliche Chancen",
+            "Kämpfe gegen andere um die besten Items",
+          ]]}
+          right={["Strategie", [
+            "Seltene Items bringen große Vorteile",
+            "Kontrolliere wenn möglich die Spawn-Bereiche",
+            "Time deine Angriffe mit den Item-Drops",
+            "Halte Gegner von Power-Ups fern",
+          ]]}
+        />
+      </Panel>
+
+      <CallToAction
+        title="Bereit zu kämpfen?"
+        text="Spring in BuildFFA und erlebe Non-Stop-PvP-Action mit Bauen! Durch wechselnde Kits, Maps und Item-Drops ist jeder Kampf anders."
+      />
+    </>
+  );
+}
+
+function Card({ icon, title, children }: { icon: string; title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
+      <div className="p-5">
+        <div className="text-3xl mb-3">{icon}</div>
+        <h2 className="text-xl font-bold mb-3">{title}</h2>
+        <p className="text-sm text-gray-300">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Panel({
+  title,
+  children,
+  inner,
+}: {
+  title: string;
+  children: React.ReactNode;
+  inner?: string;
+}) {
+  return (
+    <div className="bg-white/10 rounded-lg p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4">{title}</h2>
+      {inner ? <div className={inner}>{children}</div> : children}
+    </div>
+  );
+}
+
+function Stat({ value, label, color }: { value: string; label: string; color: string }) {
+  return (
+    <div className="text-center">
+      <div className={`text-2xl font-bold ${color}`}>{value}</div>
+      <div className="text-sm text-gray-400">{label}</div>
+    </div>
+  );
+}
+
+function TwoColList({
+  left,
+  right,
+}: {
+  left: [string, string[]];
+  right: [string, string[]];
+}) {
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <div>
+        <h3 className="font-semibold text-green-400 mb-2">{left[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {left[1].map((line) => <li key={line}>• {line}</li>)}
+        </ul>
+      </div>
+      <div>
+        <h3 className="font-semibold text-red-400 mb-2">{right[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {right[1].map((line) => <li key={line}>• {line}</li>)}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function FeatureGrid({ items }: { items: [string, string][] }) {
+  const colors = ["text-blue-400", "text-purple-400", "text-yellow-400"];
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      {items.map(([title, body], i) => (
+        <div key={title}>
+          <h3 className={`font-semibold mb-2 ${colors[i % colors.length]}`}>{title}</h3>
+          <p className="text-sm text-gray-300">{body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CallToAction({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-green-500">
+      <h2
+        className="text-lg font-bold text-green-500"
+        style={{ color: "#00de6d", textShadow: "0 0 10px #00de6d" }}
+      >
+        {title}
+      </h2>
+      <p className="mt-2">{text}</p>
+      <div className="mt-4">
+        <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-green-400">
+          play.buildffa.net
+        </span>
+      </div>
+    </div>
   );
 }

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -1,151 +1,240 @@
 import React from "react";
 import TopPage from "@/components/page/top";
+import { getServerLocale } from "@/lib/i18n/server";
 
-export default function ImprintEnglish() {
+export default async function ImprintPage() {
+  const locale = await getServerLocale();
   return (
     <>
       <TopPage />
       <section className="bg-gray-950 pt-36">
         <div className="container mx-auto px-4 py-10">
-          <h1 className="text-2xl font-bold mb-5">LEGAL NOTICE</h1>
-          
-          <h2 className="text-xl font-semibold mb-4">Service Provider</h2>
-          <p>
-            Leo Scherr
-            <br />
-            c/o Block Services
-            <br />
-            Stuttgarter Str. 106
-            <br />
-            70736 Fellbach
-          </p>
-          
-          <h2 className="text-xl font-semibold mt-8 mb-4">Contact Information</h2>
-          <p>
-            Email: <a href="mailto:contact@onthepixel.net" className="text-green-400 hover:text-green-300">contact@onthepixel.net</a>
-            <br />
-            Phone: +49 170 1850492
-          </p>
-          
-          <h2 className="text-xl font-semibold mt-8 mb-4">Social Media and Other Online Presences</h2>
-          <p>This legal notice also applies to the following social media presences and online profiles:</p>
-          <p className="mt-2">
-            <a href="https://www.youtube.com/@onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://www.youtube.com/@onthepixel
-            </a>
-          </p>
-          <p className="mt-2">
-            <a href="https://twitch.tv/onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://twitch.tv/onthepixel
-            </a>
-          </p>
-          <p className="mt-2">
-            <a href="https://discord.com/invite/Dpx3eK9t3z" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://discord.com/invite/Dpx3eK9t3z
-            </a>
-          </p>
-          <p className="mt-2">
-            <a href="https://www.tiktok.com/@onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://www.tiktok.com/@onthepixel
-            </a>
-          </p>
-          <p className="mt-2">
-            <a href="https://www.instagram.com/onthepixel_net" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://www.instagram.com/onthepixel_net
-            </a>
-          </p>
-          <p className="mt-2">
-            <a href="https://x.com/onthepixelnet" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
-              https://x.com/onthepixelnet
-            </a>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.onthepixel.net</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.onthepixel.dev</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.bedwars.net</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.tntrun.de</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.buildffa.net</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.mcwith.me</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.norizz.de</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.thejocraft.monster</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.deinmutter.de</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.gerhart.studio</span>
-          </p>
-          <p className="mt-2">
-            <span className="text-green-400">*.gerhart.dev</span>
-          </p>
-          
-          <h2 className="text-xl font-semibold mt-8 mb-4">Liability and Copyright Notices</h2>
-          <p>
-            <strong>Disclaimer:</strong> The contents of this online offering have been created carefully and according to our current 
-            knowledge. They are provided for information purposes only and do not have any legally binding effect unless they are 
-            legally required information (e.g., legal notice, privacy policy, terms and conditions, or mandatory consumer information). 
-            We reserve the right to change or delete the contents in whole or in part, provided that contractual obligations remain 
-            unaffected. All offers are non-binding and without obligation.
-          </p>
-          
-          <p className="mt-4">
-            <strong>Links to third-party websites:</strong> The content of third-party websites to which we directly or indirectly 
-            refer is outside our area of responsibility, and we do not adopt them as our own. We do not assume any responsibility 
-            for any content or disadvantages arising from the use of information accessible via the linked websites.
-          </p>
-          
-          <p className="mt-4">
-            <strong>Copyright and trademarks:</strong> All content displayed on this website, such as texts, photographs, 
-            graphics, trademarks, and logos, is protected by the respective intellectual property rights (copyrights, trademarks). 
-            Use, reproduction, etc. are subject to our rights or the rights of the respective authors or rights holders.
-          </p>
-          
-          <p className="mt-4">
-            <strong>Notice of legal violations:</strong> If you notice any legal violations within our website, please inform us. 
-            We will remove illegal content and links immediately upon becoming aware of them.
-          </p>
-          
-          <h2 className="text-xl font-semibold mt-8 mb-4">Google Analytics</h2>
-          <p>
-            This website uses Google Analytics, a web analytics service provided by Google Inc. ('Google'). Google Analytics 
-            uses 'cookies', which are text files placed on your computer to help the website analyze how users use the site. 
-            The information generated by the cookie about your use of this website (including your IP address) is transmitted 
-            to and stored by Google on servers in the United States. Google will use this information for the purpose of 
-            evaluating your use of the website, compiling reports on website activity for website operators, and providing 
-            other services relating to website activity and internet usage. Google may also transfer this information to 
-            third parties where required to do so by law, or where such third parties process the information on Google's 
-            behalf. Google will not associate your IP address with any other data held by Google. You may refuse the use 
-            of cookies by selecting the appropriate settings on your browser; however, please note that if you do this, 
-            you may not be able to use the full functionality of this website. By using this website, you consent to the 
-            processing of data about you by Google in the manner and for the purposes set out above.
-          </p>
-          
-<h2 className="text-xl font-semibold mt-8 mb-4">Contact Policy</h2>
-<p>
-  The contact options provided on this website are intended <strong>exclusively for legally relevant inquiries</strong>, 
-  including communication from attorneys or individuals with non-commercial concerns. 
-  <strong>Commercial advertising, cooperation requests, or any promotional messages are strictly prohibited</strong> 
-  and will not be answered.
-</p>
-          <p className="mt-8 text-gray-400">
-            Created with the free <a href="https://datenschutz-generator.de/" target="_blank" rel="noopener noreferrer nofollow" className="text-gray-400 hover:text-gray-300">Datenschutz-Generator.de</a> by Dr. Thomas Schwenke
-          </p>
+          {locale === "de" ? <ImprintDE /> : <ImprintEN />}
         </div>
       </section>
+    </>
+  );
+}
+
+function SocialLinks() {
+  return (
+    <>
+      <p className="mt-2">
+        <a href="https://www.youtube.com/@onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://www.youtube.com/@onthepixel
+        </a>
+      </p>
+      <p className="mt-2">
+        <a href="https://twitch.tv/onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://twitch.tv/onthepixel
+        </a>
+      </p>
+      <p className="mt-2">
+        <a href="https://discord.com/invite/Dpx3eK9t3z" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://discord.com/invite/Dpx3eK9t3z
+        </a>
+      </p>
+      <p className="mt-2">
+        <a href="https://www.tiktok.com/@onthepixel" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://www.tiktok.com/@onthepixel
+        </a>
+      </p>
+      <p className="mt-2">
+        <a href="https://www.instagram.com/onthepixel_net" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://www.instagram.com/onthepixel_net
+        </a>
+      </p>
+      <p className="mt-2">
+        <a href="https://x.com/onthepixelnet" target="_blank" rel="noopener noreferrer" className="text-green-400 hover:text-green-300">
+          https://x.com/onthepixelnet
+        </a>
+      </p>
+      {[
+        "*.onthepixel.net",
+        "*.onthepixel.dev",
+        "*.bedwars.net",
+        "*.tntrun.de",
+        "*.buildffa.net",
+        "*.mcwith.me",
+        "*.norizz.de",
+        "*.thejocraft.monster",
+        "*.deinmutter.de",
+        "*.gerhart.studio",
+        "*.gerhart.dev",
+      ].map((d) => (
+        <p className="mt-2" key={d}>
+          <span className="text-green-400">{d}</span>
+        </p>
+      ))}
+    </>
+  );
+}
+
+function ImprintEN() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">LEGAL NOTICE</h1>
+
+      <h2 className="text-xl font-semibold mb-4">Service Provider</h2>
+      <p>
+        Leo Scherr<br />
+        c/o Block Services<br />
+        Stuttgarter Str. 106<br />
+        70736 Fellbach
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Contact Information</h2>
+      <p>
+        Email: <a href="mailto:contact@onthepixel.net" className="text-green-400 hover:text-green-300">contact@onthepixel.net</a><br />
+        Phone: +49 170 1850492
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Social Media and Other Online Presences</h2>
+      <p>This legal notice also applies to the following social media presences and online profiles:</p>
+      <SocialLinks />
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Liability and Copyright Notices</h2>
+      <p>
+        <strong>Disclaimer:</strong> The contents of this online offering have been created carefully and according to our current
+        knowledge. They are provided for information purposes only and do not have any legally binding effect unless they are
+        legally required information (e.g., legal notice, privacy policy, terms and conditions, or mandatory consumer information).
+        We reserve the right to change or delete the contents in whole or in part, provided that contractual obligations remain
+        unaffected. All offers are non-binding and without obligation.
+      </p>
+
+      <p className="mt-4">
+        <strong>Links to third-party websites:</strong> The content of third-party websites to which we directly or indirectly
+        refer is outside our area of responsibility, and we do not adopt them as our own. We do not assume any responsibility
+        for any content or disadvantages arising from the use of information accessible via the linked websites.
+      </p>
+
+      <p className="mt-4">
+        <strong>Copyright and trademarks:</strong> All content displayed on this website, such as texts, photographs,
+        graphics, trademarks, and logos, is protected by the respective intellectual property rights (copyrights, trademarks).
+        Use, reproduction, etc. are subject to our rights or the rights of the respective authors or rights holders.
+      </p>
+
+      <p className="mt-4">
+        <strong>Notice of legal violations:</strong> If you notice any legal violations within our website, please inform us.
+        We will remove illegal content and links immediately upon becoming aware of them.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Google Analytics</h2>
+      <p>
+        This website uses Google Analytics, a web analytics service provided by Google Inc. (&apos;Google&apos;). Google Analytics
+        uses &apos;cookies&apos;, which are text files placed on your computer to help the website analyze how users use the site.
+        The information generated by the cookie about your use of this website (including your IP address) is transmitted
+        to and stored by Google on servers in the United States. Google will use this information for the purpose of
+        evaluating your use of the website, compiling reports on website activity for website operators, and providing
+        other services relating to website activity and internet usage. Google may also transfer this information to
+        third parties where required to do so by law, or where such third parties process the information on Google&apos;s
+        behalf. Google will not associate your IP address with any other data held by Google. You may refuse the use
+        of cookies by selecting the appropriate settings on your browser; however, please note that if you do this,
+        you may not be able to use the full functionality of this website. By using this website, you consent to the
+        processing of data about you by Google in the manner and for the purposes set out above.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Contact Policy</h2>
+      <p>
+        The contact options provided on this website are intended <strong>exclusively for legally relevant inquiries</strong>,
+        including communication from attorneys or individuals with non-commercial concerns.
+        <strong>Commercial advertising, cooperation requests, or any promotional messages are strictly prohibited</strong>
+        and will not be answered.
+      </p>
+      <p className="mt-8 text-gray-400">
+        Created with the free <a href="https://datenschutz-generator.de/" target="_blank" rel="noopener noreferrer nofollow" className="text-gray-400 hover:text-gray-300">Datenschutz-Generator.de</a> by Dr. Thomas Schwenke
+      </p>
+    </>
+  );
+}
+
+function ImprintDE() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">IMPRESSUM</h1>
+
+      <h2 className="text-xl font-semibold mb-4">Diensteanbieter</h2>
+      <p>
+        Leo Scherr<br />
+        c/o Block Services<br />
+        Stuttgarter Str. 106<br />
+        70736 Fellbach
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Kontaktmöglichkeiten</h2>
+      <p>
+        E-Mail: <a href="mailto:contact@onthepixel.net" className="text-green-400 hover:text-green-300">contact@onthepixel.net</a><br />
+        Telefon: +49 170 1850492
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Social Media und andere Online-Präsenzen</h2>
+      <p>
+        Dieses Impressum gilt auch für die folgenden Social-Media-Präsenzen und Online-Profile:
+      </p>
+      <SocialLinks />
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Haftungs- und Urheberrechtshinweise</h2>
+      <p>
+        <strong>Haftungsausschluss:</strong> Die Inhalte dieses Onlineangebotes wurden sorgfältig und nach unserem aktuellen
+        Kenntnisstand erstellt. Sie dienen ausschließlich der Information und entfalten keine rechtlich bindende Wirkung,
+        sofern es sich nicht um gesetzlich vorgeschriebene Angaben handelt (z. B. Impressum, Datenschutzerklärung, AGB oder
+        verpflichtende Verbraucherinformationen). Wir behalten uns das Recht vor, die Inhalte ganz oder teilweise zu ändern
+        oder zu löschen, soweit vertragliche Verpflichtungen davon unberührt bleiben. Alle Angebote sind freibleibend und
+        unverbindlich.
+      </p>
+
+      <p className="mt-4">
+        <strong>Links auf fremde Webseiten:</strong> Die Inhalte fremder Webseiten, auf die wir direkt oder indirekt
+        verweisen, liegen außerhalb unseres Verantwortungsbereichs und werden von uns nicht zu eigen gemacht. Für etwaige
+        Inhalte und Nachteile, die aus der Nutzung der über die verlinkten Webseiten zugänglichen Informationen entstehen,
+        übernehmen wir keine Verantwortung.
+      </p>
+
+      <p className="mt-4">
+        <strong>Urheberrechte und Markenrechte:</strong> Alle auf dieser Website dargestellten Inhalte wie Texte,
+        Fotografien, Grafiken, Marken und Logos sind durch die jeweiligen Schutzrechte (Urheberrechte, Markenrechte)
+        geschützt. Die Verwendung, Vervielfältigung usw. unterliegen unseren Rechten oder den Rechten der jeweiligen
+        Urheber bzw. Rechteinhaber.
+      </p>
+
+      <p className="mt-4">
+        <strong>Hinweise auf Rechtsverstöße:</strong> Solltest du innerhalb unserer Website Rechtsverstöße bemerken,
+        bitten wir dich, uns zu informieren. Rechtswidrige Inhalte und Links entfernen wir umgehend nach Kenntnisnahme.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Google Analytics</h2>
+      <p>
+        Diese Website nutzt Google Analytics, einen Webanalysedienst der Google Inc. („Google"). Google Analytics
+        verwendet sogenannte „Cookies", Textdateien, die auf deinem Computer gespeichert werden und die eine Analyse der
+        Benutzung der Website durch dich ermöglichen. Die durch das Cookie erzeugten Informationen über deine Benutzung
+        dieser Website (einschließlich deiner IP-Adresse) werden an einen Server von Google in den USA übertragen und
+        dort gespeichert. Google wird diese Informationen benutzen, um deine Nutzung der Website auszuwerten, Reports
+        über die Websiteaktivitäten für die Websitebetreiber zusammenzustellen und weitere mit der Websitenutzung und der
+        Internetnutzung verbundene Dienstleistungen zu erbringen. Google wird diese Informationen gegebenenfalls auch an
+        Dritte übertragen, sofern dies gesetzlich vorgeschrieben ist oder soweit Dritte diese Daten im Auftrag von Google
+        verarbeiten. Google wird in keinem Fall deine IP-Adresse mit anderen Daten von Google in Verbindung bringen. Du
+        kannst die Installation der Cookies durch eine entsprechende Einstellung deiner Browser-Software verhindern;
+        wir weisen dich jedoch darauf hin, dass du in diesem Fall gegebenenfalls nicht sämtliche Funktionen dieser
+        Website vollumfänglich nutzen kannst. Durch die Nutzung dieser Website erklärst du dich mit der Bearbeitung der
+        über dich erhobenen Daten durch Google in der zuvor beschriebenen Art und Weise und zu dem zuvor benannten Zweck
+        einverstanden.
+      </p>
+
+      <h2 className="text-xl font-semibold mt-8 mb-4">Kontaktrichtlinien</h2>
+      <p>
+        Die auf dieser Website angegebenen Kontaktmöglichkeiten sind <strong>ausschließlich für rechtlich relevante
+        Anfragen</strong> bestimmt, einschließlich Kommunikation von Anwälten oder Personen mit nicht-kommerziellen
+        Anliegen.{" "}
+        <strong>Kommerzielle Werbung, Kooperationsanfragen oder jegliche Werbebotschaften sind ausdrücklich untersagt</strong>{" "}
+        und werden nicht beantwortet.
+      </p>
+      <p className="mt-8 text-gray-400">
+        Erstellt mit dem kostenlosen{" "}
+        <a href="https://datenschutz-generator.de/" target="_blank" rel="noopener noreferrer nofollow" className="text-gray-400 hover:text-gray-300">
+          Datenschutz-Generator.de
+        </a>{" "}
+        von Dr. Thomas Schwenke
+      </p>
     </>
   );
 }

--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -8,7 +8,17 @@ import {
   DATE_LOCALES,
   DIRECTUS_LOCALES,
   Locale,
+  translations,
 } from "@/lib/i18n/translations";
+
+interface NewsTranslation {
+  id?: number;
+  News_url?: string;
+  languages_code: string;
+  title?: string | null;
+  short_description?: string | null;
+  text?: string | null;
+}
 
 interface NewsItem {
   title: string;
@@ -17,14 +27,7 @@ interface NewsItem {
   url: string;
   icon: string | null;
   short_description?: string;
-}
-
-interface NewsTranslation {
-  News_url: string;
-  languages_code: string;
-  title?: string | null;
-  short_description?: string | null;
-  text?: string | null;
+  translations?: NewsTranslation[];
 }
 
 interface PageProps {
@@ -69,37 +72,27 @@ function parseMarkdownLinks(text: string) {
 async function getNewsItem(url: string): Promise<NewsItem | null> {
   try {
     const response = await fetch(
-      `https://cms.onthepixel.net/items/News?filter%5B_and%5D%5B0%5D%5Burl%5D%5B_eq%5D=${url}`,
-      { next: { revalidate: 300 } }
-    );
-    if (!response.ok) return null;
-    const data = await response.json();
-    return data.data?.[0] ?? null;
-  } catch {
-    return null;
-  }
-}
-
-async function getNewsTranslation(
-  url: string,
-  languageCode: string,
-): Promise<NewsTranslation | null> {
-  try {
-    const response = await fetch(
-      `https://cms.onthepixel.net/items/News_translations?filter%5B_and%5D%5B0%5D%5BNews_url%5D%5B_eq%5D=${encodeURIComponent(url)}&filter%5B_and%5D%5B1%5D%5Blanguages_code%5D%5B_eq%5D=${encodeURIComponent(languageCode)}`,
+      `https://cms.onthepixel.net/items/News?fields=*,translations.*&filter%5B_and%5D%5B0%5D%5Burl%5D%5B_eq%5D=${encodeURIComponent(url)}`,
       { next: { revalidate: 300 } },
     );
     if (!response.ok) return null;
     const data = await response.json();
-    return (data.data?.[0] as NewsTranslation | undefined) ?? null;
+    return (data.data?.[0] as NewsItem | undefined) ?? null;
   } catch {
     return null;
   }
 }
 
+function findTranslation(
+  item: NewsItem,
+  languageCode: string,
+): NewsTranslation | undefined {
+  return item.translations?.find((tr) => tr.languages_code === languageCode);
+}
+
 function applyTranslation(
   item: NewsItem,
-  tr: NewsTranslation | null,
+  tr: NewsTranslation | undefined,
 ): NewsItem {
   if (!tr) return item;
   return {
@@ -115,13 +108,12 @@ function applyTranslation(
 export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
   const { url } = await params;
   const locale = await getServerLocale();
-  const [base, tr] = await Promise.all([
-    getNewsItem(url),
-    locale === "en"
-      ? Promise.resolve(null)
-      : getNewsTranslation(url, DIRECTUS_LOCALES[locale]),
-  ]);
+  const base = await getNewsItem(url);
   if (!base) return { title: "News — OnThePixel.net" };
+  const tr =
+    locale === "en"
+      ? undefined
+      : findTranslation(base, DIRECTUS_LOCALES[locale]);
   const item = applyTranslation(base, tr);
   return {
     title: `${item.title} — OnThePixel.net`,
@@ -137,16 +129,22 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
 export default async function NewsPage({ params }: PageProps) {
   const { url } = await params;
   const { locale, t } = await getServerTranslations();
-  const [base, tr] = await Promise.all([
-    getNewsItem(url),
-    locale === "en"
-      ? Promise.resolve(null)
-      : getNewsTranslation(url, DIRECTUS_LOCALES[locale]),
-  ]);
+  const base = await getNewsItem(url);
 
   if (!base) notFound();
-  const newsItem = applyTranslation(base, tr);
 
+  const tr =
+    locale === "en"
+      ? undefined
+      : findTranslation(base, DIRECTUS_LOCALES[locale]);
+
+  // Non-English locale + no translation: show confirmation page instead of
+  // the article content.
+  if (locale !== "en" && !tr) {
+    return <NotTranslatedNotice url={url} t={t} />;
+  }
+
+  const newsItem = applyTranslation(base, tr);
   const textLines = newsItem.text.split("\n");
 
   return (
@@ -162,21 +160,6 @@ export default async function NewsPage({ params }: PageProps) {
           >
             ← {t.news.backToNews}
           </Link>
-
-          {locale !== "en" && !tr && (
-            <div
-              className="mb-6 flex flex-wrap items-center gap-2 rounded-lg border border-yellow-500/30 bg-yellow-500/10 px-4 py-3 text-sm text-yellow-200"
-              style={{ fontFamily: "'DM Sans', sans-serif" }}
-            >
-              <span>{t.news.englishOnly}</span>
-              <Link
-                href={`/en/news/${url}`}
-                className="font-semibold text-yellow-100 underline decoration-yellow-300/50 underline-offset-2 transition-colors hover:text-white hover:decoration-white"
-              >
-                {t.news.readInEnglish}
-              </Link>
-            </div>
-          )}
 
           {/* Hero image */}
           <div className="relative mb-8 w-full overflow-hidden rounded-xl">
@@ -282,6 +265,71 @@ export default async function NewsPage({ params }: PageProps) {
             </Link>
           </div>
 
+        </div>
+      </section>
+    </>
+  );
+}
+
+function NotTranslatedNotice({
+  url,
+  t,
+}: {
+  url: string;
+  t: (typeof translations)[Locale];
+}) {
+  return (
+    <>
+      <TopPage />
+      <section className="bg-gray-950 min-h-screen">
+        <div className="container mx-auto max-w-2xl px-4 py-16">
+          <div className="rounded-xl border border-white/5 bg-white/[0.03] p-8 md:p-10 text-center">
+            <div className="mx-auto mb-5 flex h-14 w-14 items-center justify-center rounded-full bg-yellow-500/10 text-yellow-400 ring-1 ring-yellow-500/30">
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth={2}
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                className="size-6"
+                aria-hidden="true"
+              >
+                <circle cx="12" cy="12" r="10" />
+                <path d="M12 8v4" />
+                <path d="M12 16h.01" />
+              </svg>
+            </div>
+            <h1
+              className="mb-3 text-xl font-bold text-white md:text-2xl"
+              style={{ fontFamily: "'Syne', sans-serif" }}
+            >
+              {t.news.notTranslatedTitle}
+            </h1>
+            <p
+              className="mx-auto mb-8 max-w-md text-sm text-white/50 md:text-base"
+              style={{ fontFamily: "'DM Sans', sans-serif" }}
+            >
+              {t.news.notTranslatedText}
+            </p>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Link
+                href={`/en/news/${url}`}
+                className="rounded-lg bg-green-700 px-6 py-2.5 font-semibold text-white transition-colors hover:bg-green-600"
+                style={{ fontFamily: "'Syne', sans-serif" }}
+              >
+                {t.news.readInEnglishButton}
+              </Link>
+              <Link
+                href="/#news"
+                className="rounded-lg bg-white/5 px-6 py-2.5 font-semibold text-white ring-1 ring-white/10 transition-colors hover:bg-white/10"
+                style={{ fontFamily: "'Syne', sans-serif" }}
+              >
+                {t.news.goBack}
+              </Link>
+            </div>
+          </div>
         </div>
       </section>
     </>

--- a/src/app/tntrun/page.tsx
+++ b/src/app/tntrun/page.tsx
@@ -1,160 +1,266 @@
 import TopPage from "@/components/page/top";
+import { getServerLocale } from "@/lib/i18n/server";
 
-export default function Page() {
+export default async function Page() {
+  const locale = await getServerLocale();
   return (
     <>
       <TopPage />
       <section className="bg-gray-950 pt-36">
         <div className="container mx-auto px-4 py-10">
-          <h1 className="text-2xl font-bold mb-5">TNT RUN</h1>
-          <p className="mb-8">
-            Run for your life as the floor disappears beneath your feet! 
-            Be the last player standing on this crumbling arena.
-          </p>
-          
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
-            {/* Disappearing Floor */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">💥</div>
-                <h2 className="text-xl font-bold mb-3">Disappearing Floor</h2>
-                <p className="text-sm text-gray-300">
-                  The blocks you step on vanish after a short delay. Keep moving or fall into the void!
-                </p>
-              </div>
-            </div>
-
-            {/* Survival Challenge */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">🏃</div>
-                <h2 className="text-xl font-bold mb-3">Survival Challenge</h2>
-                <p className="text-sm text-gray-300">
-                  Outlast other players as the arena gets smaller. Use strategy and quick thinking to survive.
-                </p>
-              </div>
-            </div>
-
-            {/* Rewards */}
-            <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
-              <div className="p-5">
-                <div className="text-3xl mb-3">🏆</div>
-                <h2 className="text-xl font-bold mb-3">Rewards</h2>
-                <p className="text-sm text-gray-300">
-                  Earn Pixels for winning and completing daily quests. Unlock cosmetics and climb the leaderboards!
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Stats */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Game Information</h2>
-            <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-              <div className="text-center">
-                <div className="text-2xl font-bold text-green-400">16</div>
-                <div className="text-sm text-gray-400">Max Players</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-blue-400">1-3min</div>
-                <div className="text-sm text-gray-400">Round Length</div>
-              </div>
-              <div className="text-center">
-                <div className="text-2xl font-bold text-purple-400">3-6</div>
-                <div className="text-sm text-gray-400">Layers</div>
-              </div>
-            </div>
-          </div>
-
-          {/* How to Play */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">How to Play</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-green-400 mb-2">Basic Rules</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Blocks disappear shortly after you step on them</li>
-                  <li>• Keep moving to avoid falling</li>
-                  <li>• Last player standing wins the round</li>
-                  <li>• Falling into the void eliminates you</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-red-400 mb-2">Pro Tips</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Plan your route ahead of time</li>
-                  <li>• Cut off other players' paths</li>
-                  <li>• Stay near the center when possible</li>
-                  <li>• Don't panic - think strategically</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Game Features */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Features</h2>
-            <div className="grid md:grid-cols-3 gap-4">
-              <div>
-                <h3 className="font-semibold text-blue-400 mb-2">Daily Quests</h3>
-                <p className="text-sm text-gray-300">Complete challenges for extra Pixels and special rewards</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-purple-400 mb-2">Cosmetics</h3>
-                <p className="text-sm text-gray-300">Unlock particle effects, trails, and other visual upgrades</p>
-              </div>
-              <div>
-                <h3 className="font-semibold text-yellow-400 mb-2">Multiple Maps</h3>
-                <p className="text-sm text-gray-300">Experience different arena layouts and challenges</p>
-              </div>
-            </div>
-          </div>
-
-          {/* Strategy Guide */}
-          <div className="bg-white/10 rounded-lg p-6 mb-8">
-            <h2 className="text-xl font-bold mb-4">Winning Strategies</h2>
-            <div className="grid md:grid-cols-2 gap-6">
-              <div>
-                <h3 className="font-semibold text-blue-400 mb-2">Movement</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Keep moving but don't sprint unnecessarily</li>
-                  <li>• Use corners and edges strategically</li>
-                  <li>• Watch where other players are going</li>
-                  <li>• Save sprint for emergency escapes</li>
-                </ul>
-              </div>
-              <div>
-                <h3 className="font-semibold text-orange-400 mb-2">Tactics</h3>
-                <ul className="space-y-1 text-sm text-gray-300">
-                  <li>• Block off narrow passages</li>
-                  <li>• Force opponents into bad positions</li>
-                  <li>• Stay calm under pressure</li>
-                  <li>• Learn the timing of block destruction</li>
-                </ul>
-              </div>
-            </div>
-          </div>
-
-          {/* Call to Action */}
-          <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-green-500">
-            <h2 
-              className="text-lg font-bold text-green-500" 
-              style={{ color: "#00de6d", textShadow: "0 0 10px #00de6d" }}
-            >
-              Ready to Run?
-            </h2>
-            <p className="mt-2">
-              Join TNT Run and test your survival skills! Can you be the last one standing as the floor crumbles away? 
-              Earn Pixels, complete quests, and unlock awesome cosmetics!
-            </p>
-            <div className="mt-4">
-              <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-green-400">
-                play.tntrun.de
-              </span>
-            </div>
-          </div>
+          {locale === "de" ? <TntRunDE /> : <TntRunEN />}
         </div>
       </section>
     </>
+  );
+}
+
+function TntRunEN() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">TNT RUN</h1>
+      <p className="mb-8">
+        Run for your life as the floor disappears beneath your feet! Be the
+        last player standing on this crumbling arena.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="💥" title="Disappearing Floor">
+          The blocks you step on vanish after a short delay. Keep moving or fall into the void!
+        </Card>
+        <Card icon="🏃" title="Survival Challenge">
+          Outlast other players as the arena gets smaller. Use strategy and quick thinking to survive.
+        </Card>
+        <Card icon="🏆" title="Rewards">
+          Earn Pixels for winning and completing daily quests. Unlock cosmetics and climb the leaderboards!
+        </Card>
+      </div>
+
+      <Panel title="Game Information" inner="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <Stat value="16" label="Max Players" color="text-green-400" />
+        <Stat value="1-3min" label="Round Length" color="text-blue-400" />
+        <Stat value="3-6" label="Layers" color="text-purple-400" />
+      </Panel>
+
+      <Panel title="How to Play">
+        <TwoColList
+          left={["Basic Rules", [
+            "Blocks disappear shortly after you step on them",
+            "Keep moving to avoid falling",
+            "Last player standing wins the round",
+            "Falling into the void eliminates you",
+          ]]}
+          right={["Pro Tips", [
+            "Plan your route ahead of time",
+            "Cut off other players' paths",
+            "Stay near the center when possible",
+            "Don't panic - think strategically",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Daily Quests", "Complete challenges for extra Pixels and special rewards"],
+          ["Cosmetics", "Unlock particle effects, trails, and other visual upgrades"],
+          ["Multiple Maps", "Experience different arena layouts and challenges"],
+        ]} />
+      </Panel>
+
+      <Panel title="Winning Strategies">
+        <TwoColList
+          left={["Movement", [
+            "Keep moving but don't sprint unnecessarily",
+            "Use corners and edges strategically",
+            "Watch where other players are going",
+            "Save sprint for emergency escapes",
+          ]]}
+          right={["Tactics", [
+            "Block off narrow passages",
+            "Force opponents into bad positions",
+            "Stay calm under pressure",
+            "Learn the timing of block destruction",
+          ]]}
+        />
+      </Panel>
+
+      <CallToAction
+        title="Ready to Run?"
+        text="Join TNT Run and test your survival skills! Can you be the last one standing as the floor crumbles away? Earn Pixels, complete quests, and unlock awesome cosmetics!"
+      />
+    </>
+  );
+}
+
+function TntRunDE() {
+  return (
+    <>
+      <h1 className="text-2xl font-bold mb-5">TNT RUN</h1>
+      <p className="mb-8">
+        Lauf um dein Leben, während der Boden unter deinen Füßen verschwindet!
+        Sei der letzte Spieler in dieser bröckelnden Arena.
+      </p>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
+        <Card icon="💥" title="Verschwindender Boden">
+          Die Blöcke, auf die du trittst, verschwinden nach kurzer Verzögerung. Bleib in Bewegung oder falle ins Leere!
+        </Card>
+        <Card icon="🏃" title="Überlebens-Herausforderung">
+          Überlebe länger als die anderen, während die Arena kleiner wird. Nutze Strategie und schnelles Denken, um zu bestehen.
+        </Card>
+        <Card icon="🏆" title="Belohnungen">
+          Verdiene Pixels für Siege und das Abschließen täglicher Quests. Schalte Kosmetika frei und steige in den Bestenlisten auf!
+        </Card>
+      </div>
+
+      <Panel title="Spielinformationen" inner="grid grid-cols-2 md:grid-cols-3 gap-4">
+        <Stat value="16" label="Max. Spieler" color="text-green-400" />
+        <Stat value="1–3 Min" label="Rundenlänge" color="text-blue-400" />
+        <Stat value="3–6" label="Ebenen" color="text-purple-400" />
+      </Panel>
+
+      <Panel title="So wird gespielt">
+        <TwoColList
+          left={["Grundregeln", [
+            "Blöcke verschwinden kurz, nachdem du sie betrittst",
+            "Bleib in Bewegung, um nicht zu fallen",
+            "Der letzte verbleibende Spieler gewinnt die Runde",
+            "Wer ins Leere fällt, scheidet aus",
+          ]]}
+          right={["Profi-Tipps", [
+            "Plane deine Route im Voraus",
+            "Schneide den Weg anderer Spieler ab",
+            "Bleib wenn möglich in der Mitte",
+            "Bleib ruhig — denke strategisch",
+          ]]}
+        />
+      </Panel>
+
+      <Panel title="Features">
+        <FeatureGrid items={[
+          ["Tägliche Quests", "Schließe Herausforderungen für zusätzliche Pixels und besondere Belohnungen ab"],
+          ["Kosmetika", "Schalte Partikeleffekte, Spuren und andere visuelle Upgrades frei"],
+          ["Mehrere Maps", "Erlebe unterschiedliche Arena-Layouts und Herausforderungen"],
+        ]} />
+      </Panel>
+
+      <Panel title="Gewinn-Strategien">
+        <TwoColList
+          left={["Bewegung", [
+            "Bleib in Bewegung, aber sprinte nicht unnötig",
+            "Nutze Ecken und Kanten gezielt",
+            "Beobachte, wohin andere Spieler laufen",
+            "Spare Sprint für Notfall-Fluchten",
+          ]]}
+          right={["Taktik", [
+            "Blockiere schmale Durchgänge",
+            "Dränge Gegner in schlechte Positionen",
+            "Bleib unter Druck ruhig",
+            "Lerne die Timings der Blockzerstörung",
+          ]]}
+        />
+      </Panel>
+
+      <CallToAction
+        title="Bereit zu laufen?"
+        text="Spring in TNT Run und teste deine Überlebensfähigkeiten! Schaffst du es, als Letzter stehen zu bleiben, während der Boden zerbröckelt? Verdiene Pixels, schließe Quests ab und schalte coole Kosmetika frei!"
+      />
+    </>
+  );
+}
+
+function Card({ icon, title, children }: { icon: string; title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-white/5 rounded-lg overflow-hidden transition-transform hover:scale-105 duration-300">
+      <div className="p-5">
+        <div className="text-3xl mb-3">{icon}</div>
+        <h2 className="text-xl font-bold mb-3">{title}</h2>
+        <p className="text-sm text-gray-300">{children}</p>
+      </div>
+    </div>
+  );
+}
+
+function Panel({
+  title,
+  children,
+  inner,
+}: {
+  title: string;
+  children: React.ReactNode;
+  inner?: string;
+}) {
+  return (
+    <div className="bg-white/10 rounded-lg p-6 mb-8">
+      <h2 className="text-xl font-bold mb-4">{title}</h2>
+      {inner ? <div className={inner}>{children}</div> : children}
+    </div>
+  );
+}
+
+function Stat({ value, label, color }: { value: string; label: string; color: string }) {
+  return (
+    <div className="text-center">
+      <div className={`text-2xl font-bold ${color}`}>{value}</div>
+      <div className="text-sm text-gray-400">{label}</div>
+    </div>
+  );
+}
+
+function TwoColList({
+  left,
+  right,
+}: {
+  left: [string, string[]];
+  right: [string, string[]];
+}) {
+  return (
+    <div className="grid md:grid-cols-2 gap-6">
+      <div>
+        <h3 className="font-semibold text-green-400 mb-2">{left[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {left[1].map((line) => <li key={line}>• {line}</li>)}
+        </ul>
+      </div>
+      <div>
+        <h3 className="font-semibold text-red-400 mb-2">{right[0]}</h3>
+        <ul className="space-y-1 text-sm text-gray-300">
+          {right[1].map((line) => <li key={line}>• {line}</li>)}
+        </ul>
+      </div>
+    </div>
+  );
+}
+
+function FeatureGrid({ items }: { items: [string, string][] }) {
+  const colors = ["text-blue-400", "text-purple-400", "text-yellow-400"];
+  return (
+    <div className="grid md:grid-cols-3 gap-4">
+      {items.map(([title, body], i) => (
+        <div key={title}>
+          <h3 className={`font-semibold mb-2 ${colors[i % colors.length]}`}>{title}</h3>
+          <p className="text-sm text-gray-300">{body}</p>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CallToAction({ title, text }: { title: string; text: string }) {
+  return (
+    <div className="mt-12 p-6 bg-white/10 rounded-lg border-l-4 border-green-500">
+      <h2
+        className="text-lg font-bold text-green-500"
+        style={{ color: "#00de6d", textShadow: "0 0 10px #00de6d" }}
+      >
+        {title}
+      </h2>
+      <p className="mt-2">{text}</p>
+      <div className="mt-4">
+        <span className="inline-block bg-gray-800 rounded-md px-3 py-1 text-sm font-mono text-green-400">
+          play.tntrun.de
+        </span>
+      </div>
+    </div>
   );
 }

--- a/src/components/page/news.tsx
+++ b/src/components/page/news.tsx
@@ -7,20 +7,22 @@ import {
   Locale,
 } from "@/lib/i18n/translations";
 
+interface NewsTranslation {
+  id?: number;
+  News_url?: string;
+  languages_code: string;
+  title?: string | null;
+  short_description?: string | null;
+  text?: string | null;
+}
+
 interface NewsItem {
   title: string;
   date: string;
   short_description: string;
   url: string;
   icon: string | null;
-}
-
-interface NewsTranslation {
-  News_url: string;
-  languages_code: string;
-  title?: string | null;
-  short_description?: string | null;
-  text?: string | null;
+  translations?: NewsTranslation[];
 }
 
 function formatDate(dateStr: string, locale: Locale): string {
@@ -139,38 +141,26 @@ function NewsCard({
 
 async function getNews(): Promise<NewsItem[]> {
   try {
-    const response = await fetch("https://cms.onthepixel.net/items/News", {
-      next: { revalidate: 300 },
-    });
+    const response = await fetch(
+      "https://cms.onthepixel.net/items/News?fields=*,translations.*",
+      { next: { revalidate: 300 } },
+    );
     if (!response.ok) return [];
     const data = await response.json();
     return (data.data || []).sort(
       (a: NewsItem, b: NewsItem) =>
-        new Date(b.date).getTime() - new Date(a.date).getTime()
+        new Date(b.date).getTime() - new Date(a.date).getTime(),
     );
   } catch {
     return [];
   }
 }
 
-async function getNewsTranslations(
+function findTranslation(
+  item: NewsItem,
   languageCode: string,
-): Promise<Map<string, NewsTranslation>> {
-  try {
-    const response = await fetch(
-      `https://cms.onthepixel.net/items/News_translations?filter%5Blanguages_code%5D%5B_eq%5D=${encodeURIComponent(languageCode)}`,
-      { next: { revalidate: 300 } },
-    );
-    if (!response.ok) return new Map();
-    const data = await response.json();
-    const map = new Map<string, NewsTranslation>();
-    for (const tr of (data.data || []) as NewsTranslation[]) {
-      if (tr.News_url) map.set(tr.News_url, tr);
-    }
-    return map;
-  } catch {
-    return new Map();
-  }
+): NewsTranslation | undefined {
+  return item.translations?.find((tr) => tr.languages_code === languageCode);
 }
 
 function applyTranslation(
@@ -191,14 +181,9 @@ export default async function News() {
   const { locale, t } = await getServerTranslations();
   const directusLocale = DIRECTUS_LOCALES[locale];
 
-  const [baseItems, translationMap] = await Promise.all([
-    getNews(),
-    locale === "en"
-      ? Promise.resolve(new Map<string, NewsTranslation>())
-      : getNewsTranslations(directusLocale),
-  ]);
+  const baseItems = await getNews();
   const newsItems = baseItems.map((item) =>
-    applyTranslation(item, translationMap.get(item.url)),
+    locale === "en" ? item : applyTranslation(item, findTranslation(item, directusLocale)),
   );
   const featured = newsItems[0] ?? null;
   const rest = newsItems.slice(1, 3);

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -76,6 +76,11 @@ export const translations = {
       notFoundTitle: "News — OnThePixel.net",
       englishOnly: "This article is only available in English.",
       readInEnglish: "Click here to read it in English.",
+      notTranslatedTitle: "Article not available in your language",
+      notTranslatedText:
+        "This article hasn't been translated yet. Would you like to read the English version?",
+      readInEnglishButton: "Read in English",
+      goBack: "Go back",
     },
     error: {
       heading: "Something went wrong",
@@ -431,6 +436,11 @@ export const translations = {
       notFoundTitle: "Neuigkeiten — OnThePixel.net",
       englishOnly: "Dieser Artikel ist nur auf Englisch verfügbar.",
       readInEnglish: "Klicke hier, um ihn auf Englisch zu lesen.",
+      notTranslatedTitle: "Artikel in deiner Sprache nicht verfügbar",
+      notTranslatedText:
+        "Dieser Artikel wurde noch nicht übersetzt. Möchtest du die englische Version lesen?",
+      readInEnglishButton: "Auf Englisch lesen",
+      goBack: "Zurück",
     },
     error: {
       heading: "Etwas ist schiefgelaufen",


### PR DESCRIPTION
- Switch to Directus embedded fetch (`?fields=*,translations.*`) so the News list and detail actually receive the de-DE translation rows.
- When a German user lands on a news article that has no German translation, render a confirmation card asking whether to read the English version or go back, instead of silently displaying English.
- Translate bedwars/buildffa/tntrun pages with inline DE/EN blocks.