### PR TITLE
Force dynamic rendering to fix DYNAMIC_SERVER_USAGE on /stats/[username]

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -28,6 +28,12 @@ export const metadata: Metadata = {
     "Explore the exciting world of OnThePixel.net! Engage in thrilling minigames like Duels and BuildFFA. Dive into the pixelated fun today!",
 };
 
+// The layout reads the locale cookie/header on every request, so the whole
+// app must be rendered dynamically. Without this, routes that declare
+// `generateStaticParams` (e.g. /stats/[username]) try to prerender and
+// crash with DYNAMIC_SERVER_USAGE.
+export const dynamic = "force-dynamic";
+
 export default async function RootLayout({
   children,
 }: {

--- a/src/app/stats/[username]/duels/page.tsx
+++ b/src/app/stats/[username]/duels/page.tsx
@@ -105,9 +105,7 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
   };
 }
 
-export async function generateStaticParams() {
-  return [];
-}
+export const dynamic = "force-dynamic";
 
 export default async function DuelsKitsPage({ params }: PageProps) {
   const { username } = await params;

--- a/src/app/stats/[username]/page.tsx
+++ b/src/app/stats/[username]/page.tsx
@@ -8,12 +8,10 @@ interface PageProps {
   }>;
 }
 
-// WICHTIG: Entferne "export const dynamicParams = true;"
-// Für Static Export nur leere generateStaticParams
-export async function generateStaticParams() {
-  // Leere Liste - keine Seiten werden vorab generiert
-  return [];
-}
+// The page is rendered on-demand for each requested username — the root
+// layout already reads the locale cookie/header and so the whole tree is
+// dynamic.
+export const dynamic = "force-dynamic";
 
 const StatisticsPage: React.FC<PageProps> = async ({ params }) => {
   const { username } = await params;


### PR DESCRIPTION
The root layout reads the locale cookie/header on every request via getServerLocale(). When a child segment like /stats/[username] also declares `generateStaticParams` (returning []), Next.js tries to partially prerender it and crashes with DYNAMIC_SERVER_USAGE because the layout calls a dynamic API.

Mark the root layout and the affected stats pages as `dynamic = 'force-dynamic'` so the whole tree renders per-request, which matches what this app needs (auth session, locale cookie, CMS fetches).