### PR TITLE
SEO optimization: metadata, sitemap, robots, JSON-LD, hreflang

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -17,12 +17,26 @@ import {
 } from "@tabler/icons-react";
 import type { Metadata } from "next";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 
-export const metadata: Metadata = {
-  title: "About — OnThePixel.net",
-  description:
-    "Learn about OnThePixel.net — a Minecraft network built by players for players. Fast-paced minigames, a thriving community.",
-};
+const COPY = {
+  en: {
+    title: "About",
+    description:
+      "Learn about OnThePixel.net — a Minecraft network built by players for players. Fast-paced minigames, a thriving community.",
+  },
+  de: {
+    title: "Über uns",
+    description:
+      "Erfahre mehr über OnThePixel.net — ein Minecraft-Netzwerk von Spielern für Spieler. Schnelle Minigames, eine lebendige Community.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/about", title, description });
+}
 
 interface Game {
   name: string;

--- a/src/app/apply/builder/page.tsx
+++ b/src/app/apply/builder/page.tsx
@@ -1,8 +1,27 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import ApplicationForm, { ApplicationField } from "@/components/page/ApplicationForm";
-import { getServerTranslations } from "@/lib/i18n/server";
+import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Apply as Builder",
+    description: "Apply to join the OnThePixel.net team as a Builder.",
+  },
+  de: {
+    title: "Als Builder bewerben",
+    description: "Bewirb dich als Builder im OnThePixel.net-Team.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/apply/builder", title, description });
+}
 
 async function isPositionOpen(name: string): Promise<boolean> {
   try {

--- a/src/app/apply/developer/page.tsx
+++ b/src/app/apply/developer/page.tsx
@@ -1,8 +1,27 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import ApplicationForm, { ApplicationField } from "@/components/page/ApplicationForm";
-import { getServerTranslations } from "@/lib/i18n/server";
+import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Apply as Java Developer",
+    description: "Apply to join the OnThePixel.net team as a Java Developer.",
+  },
+  de: {
+    title: "Als Java-Developer bewerben",
+    description: "Bewirb dich als Java-Developer im OnThePixel.net-Team.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/apply/developer", title, description });
+}
 
 async function isPositionOpen(name: string): Promise<boolean> {
   try {

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -2,12 +2,27 @@ import Link from "next/link";
 import React from "react";
 import TopPage from "@/components/page/top";
 import type { Metadata } from "next";
-import { getServerTranslations } from "@/lib/i18n/server";
+import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 
-export const metadata: Metadata = {
-  title: "Apply — OnThePixel.net",
-  description: "Join the OnThePixel.net team! Apply as a Builder, Supporter or Java Developer and help shape the server.",
-};
+const META_COPY = {
+  en: {
+    title: "Apply",
+    description:
+      "Join the OnThePixel.net team! Apply as a Builder, Supporter or Java Developer and help shape the server.",
+  },
+  de: {
+    title: "Bewerben",
+    description:
+      "Werde Teil des OnThePixel.net-Teams! Bewirb dich als Builder, Supporter oder Java-Developer und gestalte den Server mit.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/apply", title, description });
+}
 
 interface Position {
   id: number;

--- a/src/app/apply/supporter/page.tsx
+++ b/src/app/apply/supporter/page.tsx
@@ -1,8 +1,27 @@
 import React from "react";
 import Link from "next/link";
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import ApplicationForm, { ApplicationField } from "@/components/page/ApplicationForm";
-import { getServerTranslations } from "@/lib/i18n/server";
+import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Apply as Supporter",
+    description: "Apply to join the OnThePixel.net team as a Supporter.",
+  },
+  de: {
+    title: "Als Supporter bewerben",
+    description: "Bewirb dich als Supporter im OnThePixel.net-Team.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/apply/supporter", title, description });
+}
 
 async function isPositionOpen(name: string): Promise<boolean> {
   try {

--- a/src/app/bedwars/page.tsx
+++ b/src/app/bedwars/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "BedWars",
+    description:
+      "Protect your bed and destroy your enemies' beds! Team-based PvP combat with strategic resource management on OnThePixel.net.",
+  },
+  de: {
+    title: "BedWars",
+    description:
+      "Beschütze dein Bett und zerstöre die Betten deiner Gegner! Team-basierte PvP-Kämpfe mit strategischem Ressourcenmanagement auf OnThePixel.net.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/bedwars", title, description });
+}
 
 export default async function Page() {
   const locale = await getServerLocale();

--- a/src/app/buildffa/page.tsx
+++ b/src/app/buildffa/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "BuildFFA",
+    description:
+      "Free-for-all combat with building. Endless rounds with kit changes, map rotations and item drops on OnThePixel.net.",
+  },
+  de: {
+    title: "BuildFFA",
+    description:
+      "Free-for-All-Kämpfe mit Bauen. Endlose Runden mit Kit-Wechseln, Map-Rotationen und Item-Drops auf OnThePixel.net.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/buildffa", title, description });
+}
 
 export default async function Page() {
   const locale = await getServerLocale();

--- a/src/app/creators/page.tsx
+++ b/src/app/creators/page.tsx
@@ -1,12 +1,28 @@
 import React from "react";
 import type { Metadata } from "next";
 import Creators, { Creator, LiveStatus } from "@/components/page/creators";
-
-export const metadata: Metadata = {
-  title: "Creators — OnThePixel.net",
-  description: "Our content creators — streamers and YouTubers playing on OnThePixel.net. Watch them live or catch their latest videos.",
-};
 import TopPage from "@/components/page/top";
+import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Creators",
+    description:
+      "Our content creators — streamers and YouTubers playing on OnThePixel.net. Watch them live or catch their latest videos.",
+  },
+  de: {
+    title: "Creators",
+    description:
+      "Unsere Content-Creators — Streamer und YouTuber, die auf OnThePixel.net spielen. Schau ihnen live zu oder entdecke ihre neuesten Videos.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/creators", title, description });
+}
 
 async function getCreatorsData() {
   try {

--- a/src/app/imprint/page.tsx
+++ b/src/app/imprint/page.tsx
@@ -1,6 +1,25 @@
 import React from "react";
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Legal Notice",
+    description: "Legal notice and provider information for OnThePixel.net.",
+  },
+  de: {
+    title: "Impressum",
+    description: "Impressum und Anbieterkennzeichnung von OnThePixel.net.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/imprint", title, description });
+}
 
 export default async function ImprintPage() {
   const locale = await getServerLocale();

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,7 @@ import { AnalyticsProvider } from "@/components/analytics-provider";
 import SessionProvider from "@/components/SessionProvider";
 import { LanguageProvider } from "@/lib/i18n/LanguageProvider";
 import { getServerLocale } from "@/lib/i18n/server";
+import { DEFAULT_OG_IMAGE, SITE_NAME, SITE_URL } from "@/lib/i18n/seo";
 
 const inter = Inter({ subsets: ["latin"] });
 const syne = Syne({
@@ -23,9 +24,62 @@ const dmSans = DM_Sans({
 });
 
 export const metadata: Metadata = {
-  title: "OnThePixel.net",
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: "OnThePixel.net — Minecraft Minigame Server",
+    template: "%s — OnThePixel.net",
+  },
   description:
-    "Explore the exciting world of OnThePixel.net! Engage in thrilling minigames like Duels and BuildFFA. Dive into the pixelated fun today!",
+    "The best Minecraft minigame server — Duels, BuildFFA, TNT Run, BedWars and more. Join thousands of players on play.onthepixel.net.",
+  applicationName: SITE_NAME,
+  keywords: [
+    "Minecraft",
+    "Minecraft server",
+    "Minigames",
+    "Duels",
+    "BuildFFA",
+    "TNT Run",
+    "BedWars",
+    "Parkour",
+    "OnThePixel",
+    "play.onthepixel.net",
+  ],
+  authors: [{ name: SITE_NAME, url: SITE_URL }],
+  creator: SITE_NAME,
+  publisher: SITE_NAME,
+  formatDetection: { email: false, telephone: false, address: false },
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    url: SITE_URL,
+    title: "OnThePixel.net — Minecraft Minigame Server",
+    description:
+      "Fast-paced Minecraft minigames. Duels, BuildFFA, TNT Run and more.",
+    images: [{ url: DEFAULT_OG_IMAGE }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    site: "@onthepixelnet",
+    creator: "@onthepixelnet",
+    title: "OnThePixel.net — Minecraft Minigame Server",
+    description:
+      "Fast-paced Minecraft minigames. Duels, BuildFFA, TNT Run and more.",
+    images: [DEFAULT_OG_IMAGE],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      "max-image-preview": "large",
+      "max-snippet": -1,
+      "max-video-preview": -1,
+    },
+  },
+  icons: {
+    icon: "/favicon.ico",
+  },
 };
 
 // The layout reads the locale cookie/header on every request, so the whole
@@ -41,10 +95,42 @@ export default async function RootLayout({
 }) {
   const initialLocale = await getServerLocale();
 
+  const orgJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: SITE_NAME,
+    url: SITE_URL,
+    logo: DEFAULT_OG_IMAGE,
+    sameAs: [
+      "https://www.youtube.com/@thebestminecraftserver",
+      "https://twitch.tv/onthepixel",
+      "https://x.com/onthepixelnet",
+      "https://www.instagram.com/onthepixel_net",
+      "https://www.tiktok.com/@onthepixel",
+      "https://discord.com/invite/Dpx3eK9t3z",
+    ],
+  };
+
+  const siteJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "WebSite",
+    name: SITE_NAME,
+    url: SITE_URL,
+    inLanguage: initialLocale === "de" ? "de-DE" : "en-US",
+  };
+
   return (
     <html lang={initialLocale}>
       <head>
         <script async src="https://analytics.intern.onthepixel.net/script.js" data-website-id="2362b4d0-3dea-4b1e-b3f8-86b0af3e4bd1"></script>
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(orgJsonLd) }}
+        />
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(siteJsonLd) }}
+        />
       </head>
       <body className={`${inter.className} ${syne.variable} ${dmSans.variable} scroll-smooth bg-gray-950`}>
         <SessionProvider>

--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -4,6 +4,7 @@ import TopPage from "@/components/page/top";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getServerTranslations, getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 import {
   DATE_LOCALES,
   DIRECTUS_LOCALES,
@@ -135,15 +136,14 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       ? undefined
       : findTranslationFor(url, DIRECTUS_LOCALES[locale], allTr);
   const item = applyTranslation(base, tr);
-  return {
-    title: `${item.title} — OnThePixel.net`,
-    description: item.short_description ?? item.text.slice(0, 160),
-    openGraph: {
-      title: item.title,
-      description: item.short_description ?? item.text.slice(0, 160),
-      images: item.icon ? [`https://cdn.onthepixel.net/${item.icon}`] : [],
-    },
-  };
+  const description = item.short_description ?? item.text.slice(0, 160);
+  return buildLocalizedMetadata({
+    locale,
+    path: `/news/${url}`,
+    title: item.title,
+    description,
+    image: item.icon ? `https://cdn.onthepixel.net/${item.icon}` : undefined,
+  });
 }
 
 export default async function NewsPage({ params }: PageProps) {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,19 +1,30 @@
 import React from "react";
 import type { Metadata } from "next";
-
-export const metadata: Metadata = {
-  title: "OnThePixel.net — Minecraft Minigame Server",
-  description: "The best Minecraft minigame server — Duels, BuildFFA, TNT Run, BedWars and more. Join thousands of players on play.onthepixel.net.",
-  openGraph: {
-    title: "OnThePixel.net",
-    description: "Fast-paced Minecraft minigames. Duels, BuildFFA, TNT Run and more.",
-    images: ["https://cdn.onthepixel.net/bf6cf0de-bf69-44d1-b107-6ad846ab7c9e"],
-  },
-};
 import Header from "@/components/page/header";
 import Trailer from "@/components/page/trailer";
 import Team from "@/components/page/team";
 import News from "@/components/page/news";
+import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const COPY = {
+  en: {
+    title: "OnThePixel.net — Minecraft Minigame Server",
+    description:
+      "The best Minecraft minigame server — Duels, BuildFFA, TNT Run, BedWars and more. Join thousands of players on play.onthepixel.net.",
+  },
+  de: {
+    title: "OnThePixel.net — Minecraft-Minigame-Server",
+    description:
+      "Der beste Minecraft-Minigame-Server — Duels, BuildFFA, TNT Run, BedWars und mehr. Spiele jetzt auf play.onthepixel.net.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/", title, description });
+}
 
 export default function Home() {
   return (

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -1,6 +1,27 @@
 import React from "react";
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "Privacy Policy",
+    description:
+      "How OnThePixel.net collects, uses and protects your personal data — GDPR-compliant privacy policy.",
+  },
+  de: {
+    title: "Datenschutz",
+    description:
+      "Wie OnThePixel.net deine personenbezogenen Daten erhebt, nutzt und schützt — DSGVO-konforme Datenschutzerklärung.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/privacy", title, description });
+}
 
 export default async function Privacy() {
   const locale = await getServerLocale();

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,16 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/i18n/seo";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: "*",
+        allow: "/",
+        disallow: ["/api/", "/apply/api/", "/redeem/api/"],
+      },
+    ],
+    sitemap: `${SITE_URL}/sitemap.xml`,
+    host: SITE_URL,
+  };
+}

--- a/src/app/sidequests/page.tsx
+++ b/src/app/sidequests/page.tsx
@@ -3,13 +3,27 @@ import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
 import type { Metadata } from "next";
-import { getServerTranslations } from "@/lib/i18n/server";
+import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 
-export const metadata: Metadata = {
-  title: "Side Quests – OnThePixel.net",
-  description:
-    "Explore the side projects and open-source tools built by the OnThePixel team.",
-};
+const META_COPY = {
+  en: {
+    title: "Side Quests",
+    description:
+      "Explore the side projects and open-source tools built by the OnThePixel team.",
+  },
+  de: {
+    title: "Side Quests",
+    description:
+      "Entdecke die Nebenprojekte und Open-Source-Tools des OnThePixel-Teams.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/sidequests", title, description });
+}
 
 interface SideQuest {
   id: number;

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,86 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/i18n/seo";
+import { SUPPORTED_LOCALES } from "@/lib/i18n/translations";
+
+interface CmsNewsItem {
+  url: string;
+  date?: string;
+}
+
+const STATIC_PATHS: { path: string; priority: number; changeFreq: MetadataRoute.Sitemap[number]["changeFrequency"] }[] = [
+  { path: "/", priority: 1.0, changeFreq: "weekly" },
+  { path: "/about", priority: 0.7, changeFreq: "monthly" },
+  { path: "/team", priority: 0.6, changeFreq: "monthly" },
+  { path: "/creators", priority: 0.6, changeFreq: "monthly" },
+  { path: "/apply", priority: 0.7, changeFreq: "weekly" },
+  { path: "/apply/builder", priority: 0.5, changeFreq: "monthly" },
+  { path: "/apply/developer", priority: 0.5, changeFreq: "monthly" },
+  { path: "/apply/supporter", priority: 0.5, changeFreq: "monthly" },
+  { path: "/leaderboard", priority: 0.8, changeFreq: "daily" },
+  { path: "/leaderboard/pixels", priority: 0.7, changeFreq: "daily" },
+  { path: "/leaderboard/buildffa", priority: 0.7, changeFreq: "daily" },
+  { path: "/leaderboard/duels", priority: 0.7, changeFreq: "daily" },
+  { path: "/leaderboard/bedwars", priority: 0.6, changeFreq: "daily" },
+  { path: "/leaderboard/parkour", priority: 0.6, changeFreq: "daily" },
+  { path: "/stats", priority: 0.7, changeFreq: "weekly" },
+  { path: "/bedwars", priority: 0.6, changeFreq: "monthly" },
+  { path: "/buildffa", priority: 0.6, changeFreq: "monthly" },
+  { path: "/tntrun", priority: 0.6, changeFreq: "monthly" },
+  { path: "/sidequests", priority: 0.5, changeFreq: "monthly" },
+  { path: "/redeem", priority: 0.4, changeFreq: "monthly" },
+  { path: "/imprint", priority: 0.3, changeFreq: "yearly" },
+  { path: "/privacy", priority: 0.3, changeFreq: "yearly" },
+];
+
+async function getNewsUrls(): Promise<CmsNewsItem[]> {
+  try {
+    const res = await fetch("https://cms.onthepixel.net/items/News", {
+      next: { revalidate: 3600 },
+    });
+    if (!res.ok) return [];
+    const data = await res.json();
+    return (data.data || []) as CmsNewsItem[];
+  } catch {
+    return [];
+  }
+}
+
+function buildLanguageAlternates(path: string): Record<string, string> {
+  const cleanPath = path === "/" ? "" : path.replace(/\/$/, "");
+  const langs: Record<string, string> = {};
+  for (const loc of SUPPORTED_LOCALES) {
+    langs[loc] =
+      loc === "en"
+        ? `${SITE_URL}${cleanPath || "/"}`
+        : `${SITE_URL}/${loc}${cleanPath}`;
+  }
+  langs["x-default"] = `${SITE_URL}${cleanPath || "/"}`;
+  return langs;
+}
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+  const news = await getNewsUrls();
+
+  const staticEntries: MetadataRoute.Sitemap = STATIC_PATHS.map(
+    ({ path, priority, changeFreq }) => ({
+      url: `${SITE_URL}${path === "/" ? "" : path}` || SITE_URL,
+      lastModified: new Date(),
+      changeFrequency: changeFreq,
+      priority,
+      alternates: { languages: buildLanguageAlternates(path) },
+    }),
+  );
+
+  const newsEntries: MetadataRoute.Sitemap = news.map((n) => {
+    const path = `/news/${n.url}`;
+    return {
+      url: `${SITE_URL}${path}`,
+      lastModified: n.date ? new Date(n.date) : new Date(),
+      changeFrequency: "monthly",
+      priority: 0.6,
+      alternates: { languages: buildLanguageAlternates(path) },
+    };
+  });
+
+  return [...staticEntries, ...newsEntries];
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -2,11 +2,27 @@ import React from "react";
 import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import PlayerStatistics from "@/components/page/PlayerStatistics";
+import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 
-export const metadata: Metadata = {
-  title: "Player Statistics — OnThePixel.net",
-  description: "Look up detailed statistics for any player on OnThePixel.net — playtime, rank, Duels, BuildFFA and more.",
-};
+const META_COPY = {
+  en: {
+    title: "Player Statistics",
+    description:
+      "Look up detailed statistics for any player on OnThePixel.net — playtime, rank, Duels, BuildFFA and more.",
+  },
+  de: {
+    title: "Spieler-Statistiken",
+    description:
+      "Sieh dir detaillierte Statistiken für jeden Spieler auf OnThePixel.net an — Spielzeit, Rang, Duels, BuildFFA und mehr.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/stats", title, description });
+}
 
 export default function StatisticsPage() {
   return (

--- a/src/app/team/page.tsx
+++ b/src/app/team/page.tsx
@@ -2,11 +2,27 @@ import React from "react";
 import Team from "@/components/page/team";
 import TopPage from "@/components/page/top";
 import type { Metadata } from "next";
+import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
 
-export const metadata: Metadata = {
-  title: "Team — OnThePixel.net",
-  description: "Meet the people behind OnThePixel.net — our developers, builders, supporters and more.",
-};
+const META_COPY = {
+  en: {
+    title: "Team",
+    description:
+      "Meet the people behind OnThePixel.net — our developers, builders, supporters and more.",
+  },
+  de: {
+    title: "Team",
+    description:
+      "Lerne die Menschen hinter OnThePixel.net kennen — unsere Entwickler, Builder, Supporter und mehr.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/team", title, description });
+}
 
 export default function Home() {
   return (

--- a/src/app/tntrun/page.tsx
+++ b/src/app/tntrun/page.tsx
@@ -1,5 +1,26 @@
+import type { Metadata } from "next";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
+import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+
+const META_COPY = {
+  en: {
+    title: "TNT Run",
+    description:
+      "Run for your life as the floor disappears beneath your feet. Be the last player standing on OnThePixel.net.",
+  },
+  de: {
+    title: "TNT Run",
+    description:
+      "Lauf um dein Leben, während der Boden unter deinen Füßen verschwindet. Sei der letzte Spieler auf OnThePixel.net.",
+  },
+} as const;
+
+export async function generateMetadata(): Promise<Metadata> {
+  const locale = await getServerLocale();
+  const { title, description } = META_COPY[locale];
+  return buildLocalizedMetadata({ locale, path: "/tntrun", title, description });
+}
 
 export default async function Page() {
   const locale = await getServerLocale();

--- a/src/lib/i18n/seo.ts
+++ b/src/lib/i18n/seo.ts
@@ -1,0 +1,61 @@
+import type { Metadata } from "next";
+import { Locale, SUPPORTED_LOCALES } from "./translations";
+
+export const SITE_URL = "https://onthepixel.net";
+export const SITE_NAME = "OnThePixel.net";
+export const DEFAULT_OG_IMAGE = `${SITE_URL}/bf6cf0de-bf69-44d1-b107-6ad846ab7c9e`;
+
+const HREFLANG_BY_LOCALE: Record<Locale, string> = {
+  en: "en",
+  de: "de",
+};
+
+/**
+ * Build a Metadata object with localized title/description, hreflang
+ * language alternates and canonical URL. `path` should start with `/`
+ * and not include a locale prefix.
+ */
+export function buildLocalizedMetadata(opts: {
+  locale: Locale;
+  path: string;
+  title: string;
+  description: string;
+  image?: string;
+}): Metadata {
+  const { locale, path, title, description } = opts;
+  const image = opts.image ?? DEFAULT_OG_IMAGE;
+  const cleanPath = path === "/" ? "" : path.replace(/\/$/, "");
+
+  const canonical =
+    locale === "en" ? `${SITE_URL}${cleanPath || "/"}` : `${SITE_URL}/${locale}${cleanPath}`;
+
+  const languages: Record<string, string> = { "x-default": `${SITE_URL}${cleanPath || "/"}` };
+  for (const loc of SUPPORTED_LOCALES) {
+    languages[HREFLANG_BY_LOCALE[loc]] =
+      loc === "en" ? `${SITE_URL}${cleanPath || "/"}` : `${SITE_URL}/${loc}${cleanPath}`;
+  }
+
+  return {
+    title,
+    description,
+    alternates: {
+      canonical,
+      languages,
+    },
+    openGraph: {
+      title,
+      description,
+      url: canonical,
+      siteName: SITE_NAME,
+      locale: locale === "de" ? "de_DE" : "en_US",
+      type: "website",
+      images: [{ url: image }],
+    },
+    twitter: {
+      card: "summary_large_image",
+      title,
+      description,
+      images: [image],
+    },
+  };
+}


### PR DESCRIPTION
- Root layout: metadataBase, default OG/Twitter tags, robots config, Organization + WebSite JSON-LD, title template.
- New `/sitemap.xml` (App Router sitemap.ts) covering all static pages plus all CMS news articles, with hreflang language alternates.
- New `/robots.txt` (App Router robots.ts) pointing at the sitemap and disallowing API routes.
- Per-page `generateMetadata` with localized title/description and hreflang `alternates.languages` (en, de, x-default) for: home, about, apply (hub + builder/developer/supporter), team, creators, bedwars, buildffa, tntrun, imprint, privacy, sidequests, stats, news/[url].
- New `src/lib/i18n/seo.ts` helper that builds canonical URLs, hreflang alternates and OG/Twitter cards in one shot.