### PR TITLE
Enhance SEO with article metadata and structured data

### DIFF
--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -4,7 +4,12 @@ import TopPage from "@/components/page/top";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
 import { getServerTranslations, getServerLocale } from "@/lib/i18n/server";
-import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import {
+  buildLocalizedMetadata,
+  SITE_NAME,
+  SITE_URL,
+  DEFAULT_OG_IMAGE,
+} from "@/lib/i18n/seo";
 import {
   DATE_LOCALES,
   DIRECTUS_LOCALES,
@@ -136,14 +141,24 @@ export async function generateMetadata({ params }: PageProps): Promise<Metadata>
       ? undefined
       : findTranslationFor(url, DIRECTUS_LOCALES[locale], allTr);
   const item = applyTranslation(base, tr);
-  const description = item.short_description ?? item.text.slice(0, 160);
+  const description = (item.short_description ?? item.text.slice(0, 160)).trim();
   return buildLocalizedMetadata({
     locale,
     path: `/news/${url}`,
     title: item.title,
     description,
-    image: item.icon ? `https://cdn.onthepixel.net/${item.icon}` : undefined,
+    type: "article",
+    publishedTime: toISODate(item.date),
+    image: item.icon
+      ? `https://cdn.onthepixel.net/${item.icon}?w=1200&h=630&fit=cover&auto=format`
+      : undefined,
+    imageAlt: item.title,
   });
+}
+
+function toISODate(dateStr: string): string | undefined {
+  const d = new Date(dateStr);
+  return isNaN(d.getTime()) ? undefined : d.toISOString();
 }
 
 export default async function NewsPage({ params }: PageProps) {
@@ -170,8 +185,43 @@ export default async function NewsPage({ params }: PageProps) {
   const newsItem = applyTranslation(base, tr);
   const textLines = newsItem.text.split("\n");
 
+  const canonicalUrl =
+    locale === "en"
+      ? `${SITE_URL}/news/${url}`
+      : `${SITE_URL}/${locale}/news/${url}`;
+  const articleImage = newsItem.icon
+    ? `https://cdn.onthepixel.net/${newsItem.icon}?w=1200&h=630&fit=cover&auto=format`
+    : DEFAULT_OG_IMAGE;
+  const publishedIso = toISODate(newsItem.date);
+  const articleDescription = (
+    newsItem.short_description ?? newsItem.text.slice(0, 160)
+  ).trim();
+
+  // NewsArticle structured data — enables rich results / Google News
+  // eligibility and lets crawlers associate the hero image with the article.
+  const articleJsonLd = {
+    "@context": "https://schema.org",
+    "@type": "NewsArticle",
+    headline: newsItem.title,
+    description: articleDescription,
+    image: [articleImage],
+    ...(publishedIso ? { datePublished: publishedIso, dateModified: publishedIso } : {}),
+    inLanguage: locale === "de" ? "de-DE" : "en-US",
+    mainEntityOfPage: { "@type": "WebPage", "@id": canonicalUrl },
+    author: { "@type": "Organization", name: SITE_NAME, url: SITE_URL },
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      logo: { "@type": "ImageObject", url: DEFAULT_OG_IMAGE },
+    },
+  };
+
   return (
     <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(articleJsonLd) }}
+      />
       <TopPage />
       <section className="bg-gray-950 min-h-screen">
         <div className="container mx-auto max-w-3xl px-4 py-10">
@@ -193,6 +243,11 @@ export default async function NewsPage({ params }: PageProps) {
                 srcSet={`https://cdn.onthepixel.net/${newsItem.icon}?w=600&auto=format 600w, https://cdn.onthepixel.net/${newsItem.icon}?w=900&auto=format 900w, https://cdn.onthepixel.net/${newsItem.icon}?w=1400&auto=format 1400w`}
                 sizes="(max-width: 768px) 100vw, 768px"
                 alt={newsItem.title}
+                width={900}
+                height={506}
+                fetchPriority="high"
+                loading="eager"
+                decoding="async"
                 className="h-56 w-full object-cover md:h-72"
               />
             ) : (

--- a/src/components/page/news.tsx
+++ b/src/components/page/news.tsx
@@ -74,6 +74,11 @@ function NewsCard({
               srcSet={`https://cdn.onthepixel.net/${item.icon}?w=400&auto=format 400w, https://cdn.onthepixel.net/${item.icon}?w=800&auto=format 800w, https://cdn.onthepixel.net/${item.icon}?w=1200&auto=format 1200w`}
               sizes="(max-width: 768px) 100vw, 50vw"
               alt={item.title}
+              width={800}
+              height={featured ? 450 : 320}
+              loading={featured ? "eager" : "lazy"}
+              fetchPriority={featured ? "high" : "auto"}
+              decoding="async"
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
             />
           ) : (

--- a/src/lib/i18n/seo.ts
+++ b/src/lib/i18n/seo.ts
@@ -14,6 +14,10 @@ const HREFLANG_BY_LOCALE: Record<Locale, string> = {
  * Build a Metadata object with localized title/description, hreflang
  * language alternates and canonical URL. `path` should start with `/`
  * and not include a locale prefix.
+ *
+ * When `type` is "article", OpenGraph article metadata (published/modified
+ * time, author) is emitted so Google and social platforms treat the page
+ * as an article rather than a generic website.
  */
 export function buildLocalizedMetadata(opts: {
   locale: Locale;
@@ -21,9 +25,14 @@ export function buildLocalizedMetadata(opts: {
   title: string;
   description: string;
   image?: string;
+  imageAlt?: string;
+  type?: "website" | "article";
+  publishedTime?: string;
+  modifiedTime?: string;
 }): Metadata {
-  const { locale, path, title, description } = opts;
+  const { locale, path, title, description, type = "website" } = opts;
   const image = opts.image ?? DEFAULT_OG_IMAGE;
+  const imageAlt = opts.imageAlt ?? title;
   const cleanPath = path === "/" ? "" : path.replace(/\/$/, "");
 
   const canonical =
@@ -35,6 +44,39 @@ export function buildLocalizedMetadata(opts: {
       loc === "en" ? `${SITE_URL}${cleanPath || "/"}` : `${SITE_URL}/${loc}${cleanPath}`;
   }
 
+  // Explicit dimensions help crawlers and social platforms render the
+  // preview without re-fetching the image (and avoid cropping surprises).
+  const ogImage = {
+    url: image,
+    width: 1200,
+    height: 630,
+    alt: imageAlt,
+  };
+
+  const openGraph: NonNullable<Metadata["openGraph"]> =
+    type === "article"
+      ? {
+          title,
+          description,
+          url: canonical,
+          siteName: SITE_NAME,
+          locale: locale === "de" ? "de_DE" : "en_US",
+          type: "article",
+          publishedTime: opts.publishedTime,
+          modifiedTime: opts.modifiedTime ?? opts.publishedTime,
+          authors: [SITE_NAME],
+          images: [ogImage],
+        }
+      : {
+          title,
+          description,
+          url: canonical,
+          siteName: SITE_NAME,
+          locale: locale === "de" ? "de_DE" : "en_US",
+          type: "website",
+          images: [ogImage],
+        };
+
   return {
     title,
     description,
@@ -42,20 +84,12 @@ export function buildLocalizedMetadata(opts: {
       canonical,
       languages,
     },
-    openGraph: {
-      title,
-      description,
-      url: canonical,
-      siteName: SITE_NAME,
-      locale: locale === "de" ? "de_DE" : "en_US",
-      type: "website",
-      images: [{ url: image }],
-    },
+    openGraph,
     twitter: {
       card: "summary_large_image",
       title,
       description,
-      images: [image],
+      images: [{ url: image, alt: imageAlt }],
     },
   };
 }


### PR DESCRIPTION
## Summary
This PR improves SEO for news articles by adding comprehensive article-specific metadata, structured data (JSON-LD), and optimizing image handling across the news section.

## Key Changes

- **Article Metadata**: Enhanced `buildLocalizedMetadata()` to support article-specific OpenGraph tags (`publishedTime`, `modifiedTime`, `authors`) and proper `og:type` distinction between "article" and "website"
- **Structured Data**: Added NewsArticle JSON-LD schema to news detail pages, enabling rich results and Google News eligibility
- **Image Optimization**: 
  - Added explicit image dimensions (1200x630) to OpenGraph metadata to prevent social platform cropping
  - Updated image URLs with query parameters for consistent sizing (`?w=1200&h=630&fit=cover&auto=format`)
  - Added `imageAlt` parameter to metadata builder for better accessibility
- **Image Performance**: Added `width`, `height`, `loading`, `fetchPriority`, and `decoding` attributes to all news images for better rendering performance and LCP optimization
- **Canonical URLs**: Properly constructed canonical URLs in news detail page considering locale prefixes
- **Date Handling**: Added `toISODate()` utility function to safely convert date strings to ISO format for metadata

## Implementation Details

- The `buildLocalizedMetadata()` function now conditionally builds OpenGraph metadata based on content type, with article type including publication dates and author information
- JSON-LD NewsArticle schema includes hero image association, language targeting, and publisher information
- Image srcSet attributes remain responsive while explicit dimensions prevent layout shift
- All changes maintain backward compatibility with existing website pages

https://claude.ai/code/session_01LHR5RfvBEKXqnJhEJn5AKo