### PR TITLE
fix(deps): force ws >= 8.21.0 to patch CVE memory exhaustion DoS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14183,9 +14183,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.20.1",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "peer": true,
       "engines": {

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1",
     "eslint-visitor-keys": "3.4.3",
-    "postcss": "^8.5.15"
+    "postcss": "^8.5.15",
+    "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
miniflare (via wrangler/opennextjs-cloudflare) pinned ws to exactly 8.20.1 which is vulnerable to memory exhaustion via tiny fragments (GHSA-xxxx, ws#37). Added an npm override to force ws >= 8.21.0.


Claude-Session: https://claude.ai/code/session_012LtFRVeywLGjvYiSd4kq3U