### PR TITLE
chore: update dependencies and lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9839,9 +9839,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.13",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.13.tgz",
-      "integrity": "sha512-sPdqC6ByMVVGvF1ynvvMo0/o+oD1VX7DaHhijt1bFgjvBkHBib4t49GoNDhf2NDta4oeUNlaGbSt5K7qjZ955Q==",
+      "version": "3.3.14",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.14.tgz",
+      "integrity": "sha512-U9kYi5bpVMEI31yC8iw4bJJp0avcHXA0W8/wNfLfnvJYzihQo2ZRPYPvpAAd570HAcCBjCTN7vnr+v4StKl1IQ==",
       "funding": [
         {
           "type": "github",
@@ -10836,9 +10836,9 @@
       }
     },
     "node_modules/path-expression-matcher": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
-      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.6.0.tgz",
+      "integrity": "sha512-e5y7RCLHKjemsgQ4eqGJtPyr10ILz25HO7flzxhTV8bgvd5yHx98DGtCAtbVW9f2TqnYI/gEVZd+vz7snrdPTw==",
       "funding": [
         {
           "type": "github",


### PR DESCRIPTION
## Summary

- All direct dependencies were already at their latest versions
- Updated `package-lock.json` with latest resolved transitive dependency versions via `npm update`

### Transitive dependency changes
| Package | Old | New |
|---|---|---|
| `nanoid` | 3.3.13 | 3.3.14 |
| `path-expression-matcher` | 1.5.0 | 1.6.0 |

## Test plan
- [ ] Run `npm install` — should produce no changes
- [ ] Run `npm run build` to verify nothing broke
- [ ] Run `npm run typecheck` and `npm run lint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PQU9AEYbp9E7zw2qXZD3Em

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQU9AEYbp9E7zw2qXZD3Em)_