### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
-        "@opennextjs/cloudflare": "^1.19.11",
+        "@opennextjs/cloudflare": "^1.20.0",
         "@radix-ui/react-avatar": "^1.2.0",
         "@radix-ui/react-dialog": "^1.1.17",
         "@radix-ui/react-icons": "^1.3.2",
@@ -3295,9 +3295,9 @@
       }
     },
     "node_modules/@opennextjs/cloudflare": {
-      "version": "1.19.11",
-      "resolved": "https://registry.npmjs.org/@opennextjs/cloudflare/-/cloudflare-1.19.11.tgz",
-      "integrity": "sha512-spZ7YsZZW9q/OJStaZlJhuklYKei5e2tNQ7PMi3DDSJ7x7167m7EYYHQZfVN5gwJBDkMR2jUDW88oHjnGz4YYw==",
+      "version": "1.20.0",
+      "resolved": "https://registry.npmjs.org/@opennextjs/cloudflare/-/cloudflare-1.20.0.tgz",
+      "integrity": "sha512-gbCIRNv4DYU5HgPQEsmyP/v+5zGZkMSGN2bYb04XfSibxiGjwNoTmtRxj/j0yOB70DLe3Xkh5f0eouXshXZtkw==",
       "license": "MIT",
       "dependencies": {
         "@ast-grep/napi": "^0.40.5",
@@ -3316,7 +3316,13 @@
       },
       "peerDependencies": {
         "next": ">=15.5.18 <16 || >=16.2.6",
+        "rclone.js": "^0.6.6",
         "wrangler": "^4.86.0"
+      },
+      "peerDependenciesMeta": {
+        "rclone.js": {
+          "optional": true
+        }
       }
     },
     "node_modules/@panva/hkdf": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^2.0.2",
-    "@opennextjs/cloudflare": "^1.19.11",
+    "@opennextjs/cloudflare": "^1.20.0",
     "@radix-ui/react-avatar": "^1.2.0",
     "@radix-ui/react-dialog": "^1.1.17",
     "@radix-ui/react-icons": "^1.3.2",


### PR DESCRIPTION
## Summary

- Bumped `@opennextjs/cloudflare` from `^1.19.11` → `^1.20.0`
- Regenerated `package-lock.json`

## Notes

`@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` had a patch update available (8.61.1 → 8.62.0), but were skipped due to a peer dependency conflict: `eslint-config-next@16.2.9` pins `typescript-eslint@8.61.1` internally, making 8.62.0 unresolvable without `--legacy-peer-deps`. They remain at `^8.61.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ApDPFvuq7kEtzjN2eaEQs7

---
_Generated by [Claude Code](https://claude.ai/code/session_01ApDPFvuq7kEtzjN2eaEQs7)_