### PR TITLE
fix: allow self-signed SSL certs for managed postgres DBs

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -8,9 +8,9 @@ export function getDb() {
   if (!_db) {
     const url = process.env.DATABASE_URL;
     if (!url) throw new Error("DATABASE_URL is not set");
-    // Only force SSL when not connecting to localhost/127.0.0.1
     const isLocal = /localhost|127\.0\.0\.1/.test(url);
-    const client = postgres(url, { ssl: isLocal ? false : "require", max: 5 });
+    // rejectUnauthorized: false allows self-signed certs used by most managed DBs
+    const client = postgres(url, { ssl: isLocal ? false : { rejectUnauthorized: false }, max: 5 });
     _db = drizzle(client, { schema });
   }
   return _db;


### PR DESCRIPTION
Fixes the `Failed query: CREATE TABLE IF NOT EXISTS news` error caused by SSL certificate rejection. `ssl: "require"` in postgres.js rejects self-signed certificates used by managed databases (Neon, Supabase, Railway, etc.). Switching to `{ rejectUnauthorized: false }` still uses TLS encryption but accepts any certificate.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FeUicibw1FKePSpz1f8K2H)_