### PR TITLE
Disable SSL verification in database connection

### DIFF
--- a/src/lib/db/index.ts
+++ b/src/lib/db/index.ts
@@ -8,9 +8,7 @@ export function getDb() {
   if (!_db) {
     const url = process.env.DATABASE_URL;
     if (!url) throw new Error("DATABASE_URL is not set");
-    const isLocal = /localhost|127\.0\.0\.1/.test(url);
-    // rejectUnauthorized: false allows self-signed certs used by most managed DBs
-    const client = postgres(url, { ssl: isLocal ? false : { rejectUnauthorized: false }, max: 5 });
+    const client = postgres(url, { ssl: false, max: 5 });
     _db = drizzle(client, { schema });
   }
   return _db;


### PR DESCRIPTION
## Summary
Simplified the database connection configuration by disabling SSL verification for all environments.

## Changes
- Removed environment-based SSL configuration logic that conditionally disabled SSL verification based on localhost detection
- Changed SSL configuration from conditional `{ rejectUnauthorized: false }` for remote databases to a blanket `ssl: false` setting
- Removed the regex pattern check for localhost/127.0.0.1 URLs

## Implementation Details
The previous implementation attempted to handle self-signed certificates used by managed databases by only disabling `rejectUnauthorized` for non-local connections. This change simplifies the approach by disabling SSL verification entirely across all environments.

https://claude.ai/code/session_01DXP5Ep7nasNL7myT9M8pYm