### PR TITLE
Add multi-language support for news articles

### DIFF
--- a/src/app/api/dashboard/news/[id]/route.ts
+++ b/src/app/api/dashboard/news/[id]/route.ts
@@ -16,8 +16,9 @@ export async function PATCH(
   const { id } = await params;
   try {
     const body = await req.json();
-    const { title, slug, short_description, content, image_url, published_at, author } = body;
-    const [item] = await getDb()
+    const { title, slug, short_description, content, image_url, published_at, author, translations } = body;
+    const db = getDb();
+    const [item] = await db
       .update(schema.news)
       .set({
         ...(title !== undefined && { title }),
@@ -32,6 +33,27 @@ export async function PATCH(
       .where(eq(schema.news.id, Number(id)))
       .returning();
     if (!item) return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    if (translations && typeof translations === "object") {
+      for (const [lang, tr] of Object.entries(translations as Record<string, { title?: string; short_description?: string; content?: string }>)) {
+        if (!lang || lang === "en") continue;
+        await db.insert(schema.newsTranslations).values({
+          news_id: Number(id),
+          language: lang,
+          title: (tr as { title?: string }).title ?? "",
+          short_description: (tr as { short_description?: string }).short_description ?? "",
+          content: (tr as { content?: string }).content ?? "",
+        }).onConflictDoUpdate({
+          target: [schema.newsTranslations.news_id, schema.newsTranslations.language],
+          set: {
+            title: (tr as { title?: string }).title ?? "",
+            short_description: (tr as { short_description?: string }).short_description ?? "",
+            content: (tr as { content?: string }).content ?? "",
+          },
+        });
+      }
+    }
+
     return NextResponse.json({ data: item });
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });

--- a/src/app/api/dashboard/news/route.ts
+++ b/src/app/api/dashboard/news/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { getDb, schema } from "@/lib/db";
 import { ensureTable } from "@/lib/db/migrate";
-import { desc, eq } from "drizzle-orm";
+import { desc } from "drizzle-orm";
 
 async function checkAuth() {
   const session = await auth();

--- a/src/app/api/dashboard/news/route.ts
+++ b/src/app/api/dashboard/news/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
 import { getDb, schema } from "@/lib/db";
 import { ensureTable } from "@/lib/db/migrate";
-import { desc } from "drizzle-orm";
+import { desc, eq } from "drizzle-orm";
 
 async function checkAuth() {
   const session = await auth();
@@ -13,8 +13,24 @@ export async function GET() {
   if (!(await checkAuth())) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   try {
     await ensureTable();
-    const items = await getDb().select().from(schema.news).orderBy(desc(schema.news.published_at));
-    return NextResponse.json({ data: items });
+    const db = getDb();
+    const items = await db.select().from(schema.news).orderBy(desc(schema.news.published_at));
+    const allTranslations = await db.select().from(schema.newsTranslations);
+
+    const data = items.map((item) => ({
+      ...item,
+      translations: allTranslations
+        .filter((tr) => tr.news_id === item.id)
+        .reduce<Record<string, { title: string; short_description: string; content: string }>>(
+          (acc, tr) => {
+            acc[tr.language] = { title: tr.title, short_description: tr.short_description, content: tr.content };
+            return acc;
+          },
+          {},
+        ),
+    }));
+
+    return NextResponse.json({ data });
   } catch (e) {
     const msg = e instanceof Error ? e.message : String(e);
     const detail = (e as { cause?: unknown })?.cause;
@@ -28,14 +44,32 @@ export async function POST(req: NextRequest) {
   try {
     await ensureTable();
     const body = await req.json();
-    const { title, slug, short_description, content, image_url, published_at, author } = body;
+    const { title, slug, short_description, content, image_url, published_at, author, translations } = body;
     if (!title || !slug || !published_at) {
       return NextResponse.json({ error: "title, slug and published_at are required" }, { status: 400 });
     }
-    const [item] = await getDb()
+    const db = getDb();
+    const [item] = await db
       .insert(schema.news)
       .values({ title, slug, short_description: short_description ?? "", content: content ?? "", image_url: image_url ?? null, published_at, author: author ?? "" })
       .returning();
+
+    if (translations && typeof translations === "object") {
+      for (const [lang, tr] of Object.entries(translations as Record<string, { title?: string; short_description?: string; content?: string }>)) {
+        if (!lang || lang === "en") continue;
+        await db.insert(schema.newsTranslations).values({
+          news_id: item.id,
+          language: lang,
+          title: tr.title ?? "",
+          short_description: tr.short_description ?? "",
+          content: tr.content ?? "",
+        }).onConflictDoUpdate({
+          target: [schema.newsTranslations.news_id, schema.newsTranslations.language],
+          set: { title: tr.title ?? "", short_description: tr.short_description ?? "", content: tr.content ?? "" },
+        });
+      }
+    }
+
     return NextResponse.json({ data: item }, { status: 201 });
   } catch (e) {
     return NextResponse.json({ error: String(e) }, { status: 500 });

--- a/src/app/dashboard/news/news-dashboard.tsx
+++ b/src/app/dashboard/news/news-dashboard.tsx
@@ -18,8 +18,15 @@ import {
   ExternalLink,
   Link as LinkIcon,
   User,
+  Languages,
 } from "lucide-react";
 import AuthGuard from "../auth-guard";
+
+type LangContent = {
+  title: string;
+  short_description: string;
+  content: string;
+};
 
 interface NewsItem {
   id?: number;
@@ -30,7 +37,17 @@ interface NewsItem {
   image_url: string | null;
   published_at: string;
   author: string;
+  translations?: Record<string, LangContent>;
 }
+
+const SUPPORTED_LANGS = [
+  { code: "en", label: "EN", name: "English" },
+  { code: "de", label: "DE", name: "Deutsch" },
+] as const;
+
+type LangCode = (typeof SUPPORTED_LANGS)[number]["code"];
+
+const EMPTY_LANG: LangContent = { title: "", short_description: "", content: "" };
 
 const EMPTY: Omit<NewsItem, "id"> = {
   title: "",
@@ -40,6 +57,7 @@ const EMPTY: Omit<NewsItem, "id"> = {
   image_url: null,
   published_at: new Date().toISOString().slice(0, 10),
   author: "",
+  translations: {},
 };
 
 function slugify(str: string) {
@@ -113,44 +131,123 @@ function DeleteModal({ item, onConfirm, onCancel, loading }: { item: NewsItem; o
   );
 }
 
+/* ── Language tab bar ─────────────────────────────────────────────────── */
+function LangTabs({ active, onChange, translations }: { active: LangCode; onChange: (l: LangCode) => void; translations: Record<string, LangContent> }) {
+  return (
+    <div className="flex items-center gap-1 rounded-xl border border-white/8 bg-white/[0.02] p-1">
+      {SUPPORTED_LANGS.map((l) => {
+        const hasContent = l.code === "en" || !!(translations[l.code]?.title || translations[l.code]?.content);
+        return (
+          <button
+            key={l.code}
+            type="button"
+            onClick={() => onChange(l.code)}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-all ${
+              active === l.code
+                ? "bg-green-500 text-black shadow"
+                : "text-white/40 hover:text-white/70"
+            }`}
+          >
+            {l.label}
+            {hasContent && active !== l.code && (
+              <span className="h-1.5 w-1.5 rounded-full bg-green-500/60" />
+            )}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
 /* ── Editor ──────────────────────────────────────────────────────────── */
 function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSave: (data: Omit<NewsItem, "id">, id?: number) => Promise<void>; onCancel: () => void }) {
   const isNew = !initial?.id;
-  const [form, setForm] = useState<Omit<NewsItem, "id">>(
-    initial
-      ? { title: initial.title, slug: initial.slug, short_description: initial.short_description, content: initial.content, image_url: initial.image_url, published_at: initial.published_at?.slice(0, 10), author: initial.author ?? "" }
-      : { ...EMPTY },
-  );
+
+  const initLang = (lang: LangCode): LangContent => {
+    if (lang === "en") {
+      return {
+        title: initial?.title ?? "",
+        short_description: initial?.short_description ?? "",
+        content: initial?.content ?? "",
+      };
+    }
+    return initial?.translations?.[lang] ?? { ...EMPTY_LANG };
+  };
+
+  const [meta, setMeta] = useState({
+    slug: initial?.slug ?? "",
+    image_url: initial?.image_url ?? null,
+    published_at: initial?.published_at?.slice(0, 10) ?? new Date().toISOString().slice(0, 10),
+    author: initial?.author ?? "",
+  });
+
+  const [langContent, setLangContent] = useState<Record<LangCode, LangContent>>({
+    en: initLang("en"),
+    de: initLang("de"),
+  });
+
+  const [activeLang, setActiveLang] = useState<LangCode>("en");
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [slugTouched, setSlugTouched] = useState(!isNew);
   const [imgError, setImgError] = useState(false);
 
-  const set = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
-    setForm((f) => ({ ...f, [key]: value }));
+  const setMetaField = <K extends keyof typeof meta>(key: K, value: (typeof meta)[K]) =>
+    setMeta((f) => ({ ...f, [key]: value }));
+
+  const setContent = (key: keyof LangContent, value: string) =>
+    setLangContent((prev) => ({ ...prev, [activeLang]: { ...prev[activeLang], [key]: value } }));
 
   const handleTitleChange = (v: string) => {
-    set("title", v);
-    if (!slugTouched) set("slug", slugify(v));
+    setContent("title", v);
+    if (activeLang === "en" && !slugTouched) setMetaField("slug", slugify(v));
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setError(null);
-    if (!form.title.trim()) return setError("Title is required.");
-    if (!form.slug.trim()) return setError("Slug is required.");
-    if (!form.published_at) return setError("Date is required.");
+    const enContent = langContent["en"];
+    if (!enContent.title.trim()) return setError("English title is required.");
+    if (!meta.slug.trim()) return setError("Slug is required.");
+    if (!meta.published_at) return setError("Date is required.");
     setLoading(true);
+
+    const translations: Record<string, LangContent> = {};
+    for (const l of SUPPORTED_LANGS) {
+      if (l.code === "en") continue;
+      const c = langContent[l.code];
+      if (c.title || c.short_description || c.content) {
+        translations[l.code] = c;
+      }
+    }
+
     try {
-      await onSave(form, initial?.id);
+      await onSave(
+        {
+          title: enContent.title,
+          slug: meta.slug,
+          short_description: enContent.short_description,
+          content: enContent.content,
+          image_url: meta.image_url,
+          published_at: meta.published_at,
+          author: meta.author,
+          translations,
+        },
+        initial?.id,
+      );
     } catch (err) {
       setError(String(err));
       setLoading(false);
     }
   };
 
-  const wordCount = form.content.trim() ? form.content.trim().split(/\s+/).length : 0;
-  const charCount = form.content.length;
+  const currentContent = langContent[activeLang];
+  const wordCount = currentContent.content.trim() ? currentContent.content.trim().split(/\s+/).length : 0;
+  const charCount = currentContent.content.length;
+
+  const translationsForTabs = Object.fromEntries(
+    SUPPORTED_LANGS.filter((l) => l.code !== "en").map((l) => [l.code, langContent[l.code]])
+  ) as Record<string, LangContent>;
 
   return (
     <div>
@@ -170,7 +267,6 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
             </span>
           )}
         </div>
-        {/* Quick save top bar */}
         <button type="button" onClick={handleSubmit} disabled={loading} className="hidden sm:flex items-center gap-2 rounded-xl bg-green-500 px-5 py-2 text-sm font-semibold text-black hover:bg-green-400 disabled:opacity-60 transition-colors">
           {loading ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
           {isNew ? "Publish" : "Save changes"}
@@ -180,29 +276,45 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
       <form onSubmit={handleSubmit} className="grid gap-6 lg:grid-cols-3">
         {/* Main content area */}
         <div className="flex flex-col gap-5 lg:col-span-2">
+          {/* Language tabs */}
+          <div className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.02] px-5 py-3.5">
+            <div className="flex items-center gap-2 text-xs text-white/30">
+              <Languages size={14} className="text-white/20" />
+              <span>Language</span>
+            </div>
+            <LangTabs active={activeLang} onChange={setActiveLang} translations={translationsForTabs} />
+          </div>
+
           {/* Title card */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-6 shadow-sm">
-            <Field label="Headline *">
-              <input
-                value={form.title}
-                onChange={(e) => handleTitleChange(e.target.value)}
-                placeholder="Write an engaging headline…"
-                className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-lg font-semibold text-white outline-none placeholder-white/15 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20 transition-all"
-              />
-            </Field>
+            <div className="mb-3 flex items-center justify-between">
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Headline</p>
+              <span className="rounded-md bg-white/5 px-2 py-0.5 text-xs text-white/20">
+                {SUPPORTED_LANGS.find((l) => l.code === activeLang)?.name}
+              </span>
+            </div>
+            <input
+              value={currentContent.title}
+              onChange={(e) => handleTitleChange(e.target.value)}
+              placeholder={activeLang === "en" ? "Write an engaging headline…" : "Überschrift auf Deutsch…"}
+              className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-lg font-semibold text-white outline-none placeholder-white/15 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20 transition-all"
+            />
+            {activeLang !== "en" && !langContent["en"].title && (
+              <p className="mt-1.5 text-xs text-yellow-500/60">English title is required before publishing.</p>
+            )}
           </div>
 
           {/* Description card */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-6 shadow-sm">
             <div className="mb-4 flex items-center justify-between">
               <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Teaser</p>
-              <span className="text-xs text-white/20">{form.short_description.length} chars</span>
+              <span className="text-xs text-white/20">{currentContent.short_description.length} chars</span>
             </div>
             <Textarea
-              value={form.short_description}
-              onChange={(e) => set("short_description", e.target.value)}
+              value={currentContent.short_description}
+              onChange={(e) => setContent("short_description", e.target.value)}
               rows={3}
-              placeholder="Short summary shown on the news list and in previews…"
+              placeholder={activeLang === "en" ? "Short summary shown on the news list…" : "Kurze Zusammenfassung auf Deutsch…"}
             />
           </div>
 
@@ -218,10 +330,10 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
             </div>
             <div className="p-6">
               <textarea
-                value={form.content}
-                onChange={(e) => set("content", e.target.value)}
+                value={currentContent.content}
+                onChange={(e) => setContent("content", e.target.value)}
                 rows={20}
-                placeholder="Write the full article here…"
+                placeholder={activeLang === "en" ? "Write the full article here…" : "Vollständigen Artikel auf Deutsch schreiben…"}
                 className="w-full rounded-xl border border-white/8 bg-black/20 px-4 py-3 text-sm text-white/90 outline-none placeholder-white/15 focus:border-green-500/30 focus:ring-1 focus:ring-green-500/15 resize-y transition-all"
                 style={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", lineHeight: "1.7" }}
               />
@@ -238,6 +350,38 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
             </div>
           )}
 
+          {/* Translations status */}
+          <div className="rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden shadow-sm">
+            <div className="border-b border-white/5 px-5 py-3.5">
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Translations</p>
+            </div>
+            <div className="flex flex-col gap-2 p-5">
+              {SUPPORTED_LANGS.map((l) => {
+                const c = langContent[l.code];
+                const filled = !!(c.title || c.content);
+                return (
+                  <button
+                    key={l.code}
+                    type="button"
+                    onClick={() => setActiveLang(l.code)}
+                    className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${
+                      activeLang === l.code ? "bg-white/8 text-white" : "text-white/40 hover:bg-white/5 hover:text-white/60"
+                    }`}
+                  >
+                    <span className="font-medium">{l.name}</span>
+                    {filled ? (
+                      <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-xs text-green-400">Done</span>
+                    ) : l.code === "en" ? (
+                      <span className="rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-500/70">Required</span>
+                    ) : (
+                      <span className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-white/20">Missing</span>
+                    )}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
           {/* Publish settings */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden shadow-sm">
             <div className="border-b border-white/5 px-5 py-3.5">
@@ -249,30 +393,30 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
                   <User size={13} className="ml-3 shrink-0 text-white/20" />
                   <input
                     type="text"
-                    value={form.author}
-                    onChange={(e) => set("author", e.target.value)}
+                    value={meta.author}
+                    onChange={(e) => setMetaField("author", e.target.value)}
                     placeholder="Name des Autors…"
                     className="flex-1 bg-transparent py-2 px-3 text-sm text-white outline-none placeholder-white/20"
                   />
                 </div>
               </Field>
               <Field label="Publish date *">
-                <Input type="date" value={form.published_at} onChange={(e) => set("published_at", e.target.value)} />
+                <Input type="date" value={meta.published_at} onChange={(e) => setMetaField("published_at", e.target.value)} />
               </Field>
               <Field label="URL slug *">
                 <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
                   <span className="shrink-0 border-r border-white/10 bg-white/5 px-3 py-2 text-xs text-white/20">/news/</span>
                   <input
                     type="text"
-                    value={form.slug}
-                    onChange={(e) => { setSlugTouched(true); set("slug", e.target.value); }}
+                    value={meta.slug}
+                    onChange={(e) => { setSlugTouched(true); setMetaField("slug", e.target.value); }}
                     placeholder="my-article"
                     className="flex-1 bg-transparent py-2 px-3 text-sm text-white outline-none placeholder-white/20"
                   />
                 </div>
-                {form.slug && (
+                {meta.slug && (
                   <a
-                    href={`/news/${form.slug}`}
+                    href={`/news/${meta.slug}`}
                     target="_blank"
                     rel="noopener noreferrer"
                     className="flex items-center gap-1 text-xs text-white/20 hover:text-green-400 transition-colors"
@@ -290,11 +434,11 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
               <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Cover image</p>
             </div>
             <div className="p-5">
-              {form.image_url && !imgError ? (
+              {meta.image_url && !imgError ? (
                 <div className="mb-4 group relative overflow-hidden rounded-xl border border-white/5">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
                   <img
-                    src={form.image_url}
+                    src={meta.image_url}
                     alt="Preview"
                     onError={() => setImgError(true)}
                     className="h-36 w-full object-cover"
@@ -302,7 +446,7 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
                   <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
                     <button
                       type="button"
-                      onClick={() => { set("image_url", null); setImgError(false); }}
+                      onClick={() => { setMetaField("image_url", null); setImgError(false); }}
                       className="flex items-center gap-1.5 rounded-lg bg-red-500/80 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500 transition-colors"
                     >
                       <X size={12} /> Remove
@@ -320,13 +464,13 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
                   <LinkIcon size={13} className="ml-3 shrink-0 text-white/20" />
                   <input
                     type="url"
-                    value={form.image_url ?? ""}
-                    onChange={(e) => { set("image_url", e.target.value || null); setImgError(false); }}
+                    value={meta.image_url ?? ""}
+                    onChange={(e) => { setMetaField("image_url", e.target.value || null); setImgError(false); }}
                     placeholder="https://…"
                     className="flex-1 bg-transparent py-2 pl-2 pr-3 text-sm text-white outline-none placeholder-white/20"
                   />
-                  {form.image_url && (
-                    <button type="button" onClick={() => { set("image_url", null); setImgError(false); }} className="mr-2 rounded p-1 text-white/20 hover:text-white/60 transition-colors">
+                  {meta.image_url && (
+                    <button type="button" onClick={() => { setMetaField("image_url", null); setImgError(false); }} className="mr-2 rounded p-1 text-white/20 hover:text-white/60 transition-colors">
                       <X size={13} />
                     </button>
                   )}
@@ -353,6 +497,7 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
 
 /* ── Table row ───────────────────────────────────────────────────────── */
 function NewsRow({ item, onEdit, onDelete }: { item: NewsItem; onEdit: (i: NewsItem) => void; onDelete: (i: NewsItem) => void }) {
+  const langCount = Object.values(item.translations ?? {}).filter((t) => t.title || t.content).length;
   return (
     <tr className="border-b border-white/5 transition-colors hover:bg-white/[0.02]">
       <td className="py-3 pl-4 pr-3">
@@ -386,6 +531,14 @@ function NewsRow({ item, onEdit, onDelete }: { item: NewsItem; onEdit: (i: NewsI
       <td className="px-3 py-3 whitespace-nowrap">
         <div className="flex items-center gap-1.5 text-xs text-white/40">
           <Calendar size={12} /> {formatDate(item.published_at)}
+        </div>
+      </td>
+      <td className="px-3 py-3 whitespace-nowrap">
+        <div className="flex items-center gap-1">
+          <span className="flex items-center gap-1 text-xs text-white/25">
+            <Languages size={11} />
+            {1 + langCount}/{SUPPORTED_LANGS.length}
+          </span>
         </div>
       </td>
       <td className="py-3 pl-3 pr-4">
@@ -504,13 +657,14 @@ function NewsDashboardContent() {
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[820px]">
+            <table className="w-full min-w-[880px]">
               <thead>
                 <tr className="border-b border-white/5">
                   <th className="py-3 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Article</th>
                   <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Description</th>
                   <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Author</th>
                   <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Date</th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Langs</th>
                   <th className="py-3 pl-3 pr-4 text-left text-xs font-medium uppercase tracking-wider text-white/30">Actions</th>
                 </tr>
               </thead>

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -24,6 +24,17 @@ export async function ensureTable() {
     await db.execute(sql`
       ALTER TABLE news ADD COLUMN IF NOT EXISTS author TEXT NOT NULL DEFAULT ''
     `);
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS news_translations (
+        id SERIAL PRIMARY KEY,
+        news_id INTEGER NOT NULL REFERENCES news(id) ON DELETE CASCADE,
+        language TEXT NOT NULL,
+        title TEXT NOT NULL DEFAULT '',
+        short_description TEXT NOT NULL DEFAULT '',
+        content TEXT NOT NULL DEFAULT '',
+        UNIQUE(news_id, language)
+      )
+    `);
     initialized = true;
   } catch (e) {
     console.error("[db] ensureTable failed:", e);

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, serial, text, timestamp } from "drizzle-orm/pg-core";
+import { pgTable, serial, text, timestamp, integer } from "drizzle-orm/pg-core";
 
 export const news = pgTable("news", {
   id: serial("id").primaryKey(),
@@ -13,5 +13,15 @@ export const news = pgTable("news", {
   updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
 });
 
+export const newsTranslations = pgTable("news_translations", {
+  id: serial("id").primaryKey(),
+  news_id: integer("news_id").notNull().references(() => news.id, { onDelete: "cascade" }),
+  language: text("language").notNull(),
+  title: text("title").notNull().default(""),
+  short_description: text("short_description").notNull().default(""),
+  content: text("content").notNull().default(""),
+});
+
 export type NewsItem = typeof news.$inferSelect;
 export type NewNewsItem = typeof news.$inferInsert;
+export type NewsTranslationItem = typeof newsTranslations.$inferSelect;


### PR DESCRIPTION
## Summary
This PR adds comprehensive multi-language support to the news dashboard, allowing articles to be published in English and German with separate content for each language.

## Key Changes

### Frontend (news-dashboard.tsx)
- Added language tab component (`LangTabs`) to switch between supported languages (EN, DE)
- Refactored form state management to separate language-specific content from metadata:
  - `langContent`: Stores title, short_description, and content per language
  - `meta`: Stores slug, image_url, published_at, and author (shared across languages)
- Added language-aware input fields with localized placeholders
- Implemented translations status panel showing completion status for each language
- Added language count indicator in the news table showing how many translations exist
- English title is now required before publishing; other languages are optional
- Updated table to display translation coverage (e.g., "2/2" languages)

### Backend API (route.ts files)
- **GET /api/dashboard/news**: Fetches news items with their translations, mapping them into a `translations` object keyed by language code
- **POST /api/dashboard/news**: Accepts translations object and inserts/upserts translation records using `onConflictDoUpdate`
- **PATCH /api/dashboard/news/[id]**: Updates news item and handles translation upserts with conflict resolution

### Database Schema (schema.ts & migrate.ts)
- Created new `newsTranslations` table with:
  - Foreign key reference to `news` table with cascade delete
  - Language code, title, short_description, and content fields
  - Unique constraint on (news_id, language) to prevent duplicates
- Added migration logic to create the table if it doesn't exist

### Configuration
- Defined `SUPPORTED_LANGS` constant with English and German support
- Type-safe language code handling with `LangCode` type

## Notable Implementation Details
- English content is stored in the main `news` table; other languages in `newsTranslations`
- Translations are optional except for English, which is required for publishing
- Language tabs show visual indicators (green dots) for languages with existing content
- Form validation ensures English title is present before allowing publication
- Slug auto-generation only occurs when editing English content and slug hasn't been manually touched

https://claude.ai/code/session_01YV6mSAoJLhXqnfmD3m9PMs