### PR TITLE
Block-based article editor with rich content types

### DIFF
--- a/src/app/dashboard/news/news-dashboard.tsx
+++ b/src/app/dashboard/news/news-dashboard.tsx
@@ -29,7 +29,7 @@ import {
 } from "lucide-react";
 import AuthGuard from "../auth-guard";
 
-/* ── Block types ──────────────────────────────────────────────────────── */
+/* --- Block types --- */
 export type Block =
   | { id: string; type: "paragraph"; content: string }
   | { id: string; type: "heading"; level: 2 | 3; content: string }
@@ -58,7 +58,7 @@ function stringToBlocks(content: string): Block[] {
   return [{ id: makeId(), type: "paragraph", content }];
 }
 
-/* ── Types ────────────────────────────────────────────────────────────── */
+/* --- Types --- */
 type LangContent = {
   title: string;
   short_description: string;
@@ -111,7 +111,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-/* ── Block editor ─────────────────────────────────────────────────────── */
+/* --- Block editor --- */
 const BLOCK_TYPES: { type: Block["type"]; label: string; icon: React.ReactNode; description: string }[] = [
   { type: "paragraph", label: "Paragraph", icon: <Type size={14} />, description: "Fließtext mit Links" },
   { type: "heading", label: "Überschrift", icon: <span className="text-xs font-black">H</span>, description: "H2 oder H3 Überschrift" },
@@ -347,7 +347,7 @@ function BlockEditor({ blocks, onChange }: { blocks: Block[]; onChange: (b: Bloc
   );
 }
 
-/* ── Delete modal ────────────────────────────────────────────────────── */
+/* --- Delete modal --- */
 function DeleteModal({ item, onConfirm, onCancel, loading }: { item: NewsItem; onConfirm: () => void; onCancel: () => void; loading: boolean }) {
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
@@ -374,7 +374,7 @@ function DeleteModal({ item, onConfirm, onCancel, loading }: { item: NewsItem; o
   );
 }
 
-/* ── Language tab bar ─────────────────────────────────────────────────── */
+/* --- Language tab bar --- */
 function LangTabs({ active, onChange, translations }: { active: LangCode; onChange: (l: LangCode) => void; translations: Record<string, LangContent> }) {
   return (
     <div className="flex items-center gap-1 rounded-xl border border-white/8 bg-white/[0.02] p-1">
@@ -392,7 +392,7 @@ function LangTabs({ active, onChange, translations }: { active: LangCode; onChan
   );
 }
 
-/* ── Editor ──────────────────────────────────────────────────────────── */
+/* --- Editor --- */
 function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSave: (data: Omit<NewsItem, "id">, id?: number) => Promise<void>; onCancel: () => void }) {
   const isNew = !initial?.id;
 
@@ -680,7 +680,7 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
   );
 }
 
-/* ── Table row ───────────────────────────────────────────────────────── */
+/* --- Table row --- */
 function NewsRow({ item, onEdit, onDelete }: { item: NewsItem; onEdit: (i: NewsItem) => void; onDelete: (i: NewsItem) => void }) {
   const langCount = Object.values(item.translations ?? {}).filter((t) => t.title || t.content).length;
   return (
@@ -741,7 +741,7 @@ function NewsRow({ item, onEdit, onDelete }: { item: NewsItem; onEdit: (i: NewsI
   );
 }
 
-/* ── Main ────────────────────────────────────────────────────────────── */
+/* --- Main --- */
 function NewsDashboardContent() {
   const [items, setItems] = useState<NewsItem[]>([]);
   const [loading, setLoading] = useState(true);

--- a/src/app/dashboard/news/news-dashboard.tsx
+++ b/src/app/dashboard/news/news-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback, useId } from "react";
+import React, { useEffect, useState, useCallback } from "react";
 import {
   Newspaper,
   Search,

--- a/src/app/dashboard/news/news-dashboard.tsx
+++ b/src/app/dashboard/news/news-dashboard.tsx
@@ -19,7 +19,7 @@ import {
   Link as LinkIcon,
   User,
   Languages,
-  Youtube,
+  CirclePlay,
   Type,
   Minus,
   Info,
@@ -115,7 +115,7 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
 const BLOCK_TYPES: { type: Block["type"]; label: string; icon: React.ReactNode; description: string }[] = [
   { type: "paragraph", label: "Paragraph", icon: <Type size={14} />, description: "Fließtext mit Links" },
   { type: "heading", label: "Überschrift", icon: <span className="text-xs font-black">H</span>, description: "H2 oder H3 Überschrift" },
-  { type: "youtube", label: "YouTube", icon: <Youtube size={14} />, description: "YouTube-Video einbetten" },
+  { type: "youtube", label: "YouTube", icon: <CirclePlay size={14} />, description: "YouTube-Video einbetten" },
   { type: "image", label: "Bild", icon: <ImageIcon size={14} />, description: "Bild mit Bildunterschrift" },
   { type: "callout", label: "Kachel", icon: <Info size={14} />, description: "Info-, Tipp- oder Warnbox" },
   { type: "divider", label: "Trennlinie", icon: <Minus size={14} />, description: "Horizontale Trennlinie" },
@@ -227,7 +227,7 @@ function BlockEditor({ blocks, onChange }: { blocks: Block[]; onChange: (b: Bloc
           {block.type === "youtube" && (
             <div className="flex flex-col gap-3">
               <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
-                <Youtube size={14} className="ml-3 shrink-0 text-red-400" />
+                <CirclePlay size={14} className="ml-3 shrink-0 text-red-400" />
                 <input
                   type="url"
                   value={block.url}

--- a/src/app/dashboard/news/news-dashboard.tsx
+++ b/src/app/dashboard/news/news-dashboard.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useId } from "react";
 import {
   Newspaper,
   Search,
@@ -19,9 +19,46 @@ import {
   Link as LinkIcon,
   User,
   Languages,
+  Youtube,
+  Type,
+  Minus,
+  Info,
+  ChevronUp,
+  ChevronDown,
+  LayoutTemplate,
 } from "lucide-react";
 import AuthGuard from "../auth-guard";
 
+/* ── Block types ──────────────────────────────────────────────────────── */
+export type Block =
+  | { id: string; type: "paragraph"; content: string }
+  | { id: string; type: "heading"; level: 2 | 3; content: string }
+  | { id: string; type: "youtube"; url: string }
+  | { id: string; type: "image"; url: string; caption: string }
+  | { id: string; type: "callout"; variant: "info" | "warning" | "tip" | "success"; title: string; content: string }
+  | { id: string; type: "divider" };
+
+function makeId() {
+  return Math.random().toString(36).slice(2, 10);
+}
+
+function blocksToString(blocks: Block[]): string {
+  return JSON.stringify(blocks);
+}
+
+function stringToBlocks(content: string): Block[] {
+  if (!content.trim()) return [{ id: makeId(), type: "paragraph", content: "" }];
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed[0]?.type) {
+      return parsed as Block[];
+    }
+  } catch { /* not JSON */ }
+  // Legacy plain-text → single paragraph block
+  return [{ id: makeId(), type: "paragraph", content }];
+}
+
+/* ── Types ────────────────────────────────────────────────────────────── */
 type LangContent = {
   title: string;
   short_description: string;
@@ -49,17 +86,6 @@ type LangCode = (typeof SUPPORTED_LANGS)[number]["code"];
 
 const EMPTY_LANG: LangContent = { title: "", short_description: "", content: "" };
 
-const EMPTY: Omit<NewsItem, "id"> = {
-  title: "",
-  slug: "",
-  short_description: "",
-  content: "",
-  image_url: null,
-  published_at: new Date().toISOString().slice(0, 10),
-  author: "",
-  translations: {},
-};
-
 function slugify(str: string) {
   return str
     .toLowerCase()
@@ -76,7 +102,6 @@ function formatDate(d: string) {
   }
 }
 
-/* ── Helpers ─────────────────────────────────────────────────────────── */
 function Field({ label, children }: { label: string; children: React.ReactNode }) {
   return (
     <div className="flex flex-col gap-1.5">
@@ -86,21 +111,239 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
   );
 }
 
-function Input({ ...props }: React.InputHTMLAttributes<HTMLInputElement>) {
-  return (
-    <input
-      {...props}
-      className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none placeholder-white/20 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
-    />
-  );
+/* ── Block editor ─────────────────────────────────────────────────────── */
+const BLOCK_TYPES: { type: Block["type"]; label: string; icon: React.ReactNode; description: string }[] = [
+  { type: "paragraph", label: "Paragraph", icon: <Type size={14} />, description: "Fließtext mit Links" },
+  { type: "heading", label: "Überschrift", icon: <span className="text-xs font-black">H</span>, description: "H2 oder H3 Überschrift" },
+  { type: "youtube", label: "YouTube", icon: <Youtube size={14} />, description: "YouTube-Video einbetten" },
+  { type: "image", label: "Bild", icon: <ImageIcon size={14} />, description: "Bild mit Bildunterschrift" },
+  { type: "callout", label: "Kachel", icon: <Info size={14} />, description: "Info-, Tipp- oder Warnbox" },
+  { type: "divider", label: "Trennlinie", icon: <Minus size={14} />, description: "Horizontale Trennlinie" },
+];
+
+function newBlock(type: Block["type"]): Block {
+  const id = makeId();
+  switch (type) {
+    case "paragraph": return { id, type: "paragraph", content: "" };
+    case "heading": return { id, type: "heading", level: 2, content: "" };
+    case "youtube": return { id, type: "youtube", url: "" };
+    case "image": return { id, type: "image", url: "", caption: "" };
+    case "callout": return { id, type: "callout", variant: "info", title: "", content: "" };
+    case "divider": return { id, type: "divider" };
+  }
 }
 
-function Textarea({ ...props }: React.TextareaHTMLAttributes<HTMLTextAreaElement>) {
+function extractYoutubeId(url: string): string | null {
+  const m = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/);
+  return m ? m[1] : null;
+}
+
+const CALLOUT_VARIANTS = [
+  { value: "info", label: "Info", color: "text-blue-400" },
+  { value: "tip", label: "Tipp", color: "text-green-400" },
+  { value: "warning", label: "Warnung", color: "text-yellow-400" },
+  { value: "success", label: "Erfolg", color: "text-emerald-400" },
+] as const;
+
+function BlockEditor({ blocks, onChange }: { blocks: Block[]; onChange: (b: Block[]) => void }) {
+  const [showAddMenu, setShowAddMenu] = useState(false);
+
+  const update = (id: string, patch: Partial<Block>) =>
+    onChange(blocks.map((b) => (b.id === id ? ({ ...b, ...patch } as Block) : b)));
+
+  const remove = (id: string) => onChange(blocks.filter((b) => b.id !== id));
+
+  const move = (id: string, dir: -1 | 1) => {
+    const idx = blocks.findIndex((b) => b.id === id);
+    if (idx < 0) return;
+    const next = idx + dir;
+    if (next < 0 || next >= blocks.length) return;
+    const arr = [...blocks];
+    [arr[idx], arr[next]] = [arr[next], arr[idx]];
+    onChange(arr);
+  };
+
+  const add = (type: Block["type"]) => {
+    onChange([...blocks, newBlock(type)]);
+    setShowAddMenu(false);
+  };
+
   return (
-    <textarea
-      {...props}
-      className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none placeholder-white/20 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20 resize-y"
-    />
+    <div className="flex flex-col gap-3">
+      {blocks.map((block, idx) => (
+        <div key={block.id} className="group relative rounded-xl border border-white/8 bg-black/20 p-4">
+          {/* Block controls */}
+          <div className="absolute right-2 top-2 flex items-center gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+            <button type="button" onClick={() => move(block.id, -1)} disabled={idx === 0} className="rounded p-1 text-white/30 hover:bg-white/10 hover:text-white disabled:opacity-20 transition-colors">
+              <ChevronUp size={13} />
+            </button>
+            <button type="button" onClick={() => move(block.id, 1)} disabled={idx === blocks.length - 1} className="rounded p-1 text-white/30 hover:bg-white/10 hover:text-white disabled:opacity-20 transition-colors">
+              <ChevronDown size={13} />
+            </button>
+            <button type="button" onClick={() => remove(block.id)} className="rounded p-1 text-white/30 hover:bg-red-500/20 hover:text-red-400 transition-colors">
+              <Trash2 size={13} />
+            </button>
+          </div>
+
+          {/* Block type label */}
+          <div className="mb-3 flex items-center gap-1.5">
+            <span className="flex items-center gap-1 rounded-md bg-white/5 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-wider text-white/25">
+              {BLOCK_TYPES.find((t) => t.type === block.type)?.icon}
+              {BLOCK_TYPES.find((t) => t.type === block.type)?.label}
+            </span>
+          </div>
+
+          {block.type === "paragraph" && (
+            <textarea
+              value={block.content}
+              onChange={(e) => update(block.id, { content: e.target.value })}
+              rows={5}
+              placeholder="Text schreiben… [Linktext](https://…) für Links"
+              className="w-full rounded-lg border border-white/8 bg-white/5 px-3 py-2 text-sm text-white/90 outline-none placeholder-white/20 focus:border-green-500/30 focus:ring-1 focus:ring-green-500/15 resize-y transition-all"
+              style={{ fontFamily: "'DM Sans', sans-serif" }}
+            />
+          )}
+
+          {block.type === "heading" && (
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-2">
+                {([2, 3] as const).map((lvl) => (
+                  <button key={lvl} type="button" onClick={() => update(block.id, { level: lvl })}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-bold transition-colors ${block.level === lvl ? "bg-green-500 text-black" : "border border-white/10 bg-white/5 text-white/40 hover:text-white"}`}>
+                    H{lvl}
+                  </button>
+                ))}
+              </div>
+              <input
+                value={block.content}
+                onChange={(e) => update(block.id, { content: e.target.value })}
+                placeholder="Überschrift…"
+                className="w-full rounded-lg border border-white/8 bg-white/5 px-3 py-2 font-semibold text-white outline-none placeholder-white/20 focus:border-green-500/30 focus:ring-1 focus:ring-green-500/15 transition-all"
+                style={{ fontSize: block.level === 2 ? "1.25rem" : "1.05rem" }}
+              />
+            </div>
+          )}
+
+          {block.type === "youtube" && (
+            <div className="flex flex-col gap-3">
+              <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
+                <Youtube size={14} className="ml-3 shrink-0 text-red-400" />
+                <input
+                  type="url"
+                  value={block.url}
+                  onChange={(e) => update(block.id, { url: e.target.value })}
+                  placeholder="https://youtube.com/watch?v=… oder https://youtu.be/…"
+                  className="flex-1 bg-transparent py-2 pl-2 pr-3 text-sm text-white outline-none placeholder-white/20"
+                />
+              </div>
+              {block.url && extractYoutubeId(block.url) && (
+                <div className="overflow-hidden rounded-lg border border-white/5 bg-black">
+                  <div className="relative aspect-video w-full">
+                    <iframe
+                      src={`https://www.youtube.com/embed/${extractYoutubeId(block.url)}`}
+                      className="absolute inset-0 h-full w-full"
+                      allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                      allowFullScreen
+                      title="YouTube preview"
+                    />
+                  </div>
+                </div>
+              )}
+              {block.url && !extractYoutubeId(block.url) && (
+                <p className="text-xs text-red-400/70">Keine gültige YouTube-URL erkannt.</p>
+              )}
+            </div>
+          )}
+
+          {block.type === "image" && (
+            <div className="flex flex-col gap-2">
+              <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
+                <LinkIcon size={13} className="ml-3 shrink-0 text-white/20" />
+                <input
+                  type="url"
+                  value={block.url}
+                  onChange={(e) => update(block.id, { url: e.target.value })}
+                  placeholder="Bild-URL (https://…)"
+                  className="flex-1 bg-transparent py-2 pl-2 pr-3 text-sm text-white outline-none placeholder-white/20"
+                />
+              </div>
+              {block.url && (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img src={block.url} alt="preview" className="max-h-48 w-full rounded-lg object-contain border border-white/5 bg-black/30" />
+              )}
+              <input
+                value={block.caption}
+                onChange={(e) => update(block.id, { caption: e.target.value })}
+                placeholder="Bildunterschrift (optional)"
+                className="w-full rounded-lg border border-white/8 bg-white/5 px-3 py-2 text-sm text-white/70 outline-none placeholder-white/20 focus:border-green-500/30 transition-all"
+              />
+            </div>
+          )}
+
+          {block.type === "callout" && (
+            <div className="flex flex-col gap-2">
+              <div className="flex gap-2 flex-wrap">
+                {CALLOUT_VARIANTS.map((v) => (
+                  <button key={v.value} type="button" onClick={() => update(block.id, { variant: v.value })}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-semibold transition-colors ${block.variant === v.value ? "bg-white/15 " + v.color : "border border-white/10 bg-white/5 text-white/30 hover:text-white"}`}>
+                    {v.label}
+                  </button>
+                ))}
+              </div>
+              <input
+                value={block.title}
+                onChange={(e) => update(block.id, { title: e.target.value })}
+                placeholder="Titel der Kachel (optional)"
+                className="w-full rounded-lg border border-white/8 bg-white/5 px-3 py-2 text-sm font-semibold text-white outline-none placeholder-white/20 focus:border-green-500/30 transition-all"
+              />
+              <textarea
+                value={block.content}
+                onChange={(e) => update(block.id, { content: e.target.value })}
+                rows={3}
+                placeholder="Inhalt der Kachel…"
+                className="w-full rounded-lg border border-white/8 bg-white/5 px-3 py-2 text-sm text-white/80 outline-none placeholder-white/20 focus:border-green-500/30 resize-y transition-all"
+              />
+            </div>
+          )}
+
+          {block.type === "divider" && (
+            <div className="flex items-center gap-3 py-2">
+              <div className="h-px flex-1 bg-white/10" />
+              <span className="text-xs text-white/20">Trennlinie</span>
+              <div className="h-px flex-1 bg-white/10" />
+            </div>
+          )}
+        </div>
+      ))}
+
+      {/* Add block button */}
+      <div className="relative">
+        <button
+          type="button"
+          onClick={() => setShowAddMenu((v) => !v)}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-white/10 py-3 text-sm text-white/30 transition-colors hover:border-green-500/30 hover:text-green-400"
+        >
+          <Plus size={15} />
+          Block hinzufügen
+        </button>
+        {showAddMenu && (
+          <div className="absolute bottom-full left-0 z-20 mb-2 w-full overflow-hidden rounded-xl border border-white/10 bg-gray-900 shadow-2xl">
+            <div className="grid grid-cols-2 gap-1 p-2 sm:grid-cols-3">
+              {BLOCK_TYPES.map((bt) => (
+                <button key={bt.type} type="button" onClick={() => add(bt.type)}
+                  className="flex flex-col items-start gap-1 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-white/8">
+                  <span className="flex items-center gap-1.5 text-sm font-semibold text-white/80">
+                    <span className="text-white/40">{bt.icon}</span>
+                    {bt.label}
+                  </span>
+                  <span className="text-[10px] text-white/25">{bt.description}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
   );
 }
 
@@ -115,15 +358,15 @@ function DeleteModal({ item, onConfirm, onCancel, loading }: { item: NewsItem; o
             <Trash2 size={18} className="text-red-400" />
           </div>
           <div>
-            <p className="font-semibold text-white">Delete article</p>
-            <p className="text-xs text-white/40">This cannot be undone.</p>
+            <p className="font-semibold text-white">Artikel löschen</p>
+            <p className="text-xs text-white/40">Das kann nicht rückgängig gemacht werden.</p>
           </div>
         </div>
         <p className="mb-6 rounded-lg bg-white/5 px-3 py-2 text-sm text-white/70">&quot;{item.title}&quot;</p>
         <div className="flex gap-3">
-          <button onClick={onCancel} className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 hover:bg-white/5 transition-colors">Cancel</button>
+          <button onClick={onCancel} className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 hover:bg-white/5 transition-colors">Abbrechen</button>
           <button onClick={onConfirm} disabled={loading} className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500 py-2 text-sm font-semibold text-white hover:bg-red-600 disabled:opacity-60 transition-colors">
-            {loading ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />} Delete
+            {loading ? <Loader2 size={14} className="animate-spin" /> : <Trash2 size={14} />} Löschen
           </button>
         </div>
       </div>
@@ -138,20 +381,10 @@ function LangTabs({ active, onChange, translations }: { active: LangCode; onChan
       {SUPPORTED_LANGS.map((l) => {
         const hasContent = l.code === "en" || !!(translations[l.code]?.title || translations[l.code]?.content);
         return (
-          <button
-            key={l.code}
-            type="button"
-            onClick={() => onChange(l.code)}
-            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-all ${
-              active === l.code
-                ? "bg-green-500 text-black shadow"
-                : "text-white/40 hover:text-white/70"
-            }`}
-          >
+          <button key={l.code} type="button" onClick={() => onChange(l.code)}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-xs font-semibold transition-all ${active === l.code ? "bg-green-500 text-black shadow" : "text-white/40 hover:text-white/70"}`}>
             {l.label}
-            {hasContent && active !== l.code && (
-              <span className="h-1.5 w-1.5 rounded-full bg-green-500/60" />
-            )}
+            {hasContent && active !== l.code && <span className="h-1.5 w-1.5 rounded-full bg-green-500/60" />}
           </button>
         );
       })}
@@ -163,25 +396,21 @@ function LangTabs({ active, onChange, translations }: { active: LangCode; onChan
 function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSave: (data: Omit<NewsItem, "id">, id?: number) => Promise<void>; onCancel: () => void }) {
   const isNew = !initial?.id;
 
-  const initLang = (lang: LangCode): LangContent => {
-    if (lang === "en") {
-      return {
-        title: initial?.title ?? "",
-        short_description: initial?.short_description ?? "",
-        content: initial?.content ?? "",
-      };
-    }
-    return initial?.translations?.[lang] ?? { ...EMPTY_LANG };
+  const initBlocks = (lang: LangCode): Block[] => {
+    if (lang === "en") return stringToBlocks(initial?.content ?? "");
+    return stringToBlocks(initial?.translations?.[lang]?.content ?? "");
   };
 
-  const [meta, setMeta] = useState({
-    slug: initial?.slug ?? "",
-    image_url: initial?.image_url ?? null,
+  const [meta, setMeta] = useState({ slug: initial?.slug ?? "", image_url: initial?.image_url ?? null });
+
+  const [langMeta, setLangMeta] = useState<Record<LangCode, { title: string; short_description: string }>>({
+    en: { title: initial?.title ?? "", short_description: initial?.short_description ?? "" },
+    de: { title: initial?.translations?.de?.title ?? "", short_description: initial?.translations?.de?.short_description ?? "" },
   });
 
-  const [langContent, setLangContent] = useState<Record<LangCode, LangContent>>({
-    en: initLang("en"),
-    de: initLang("de"),
+  const [langBlocks, setLangBlocks] = useState<Record<LangCode, Block[]>>({
+    en: initBlocks("en"),
+    de: initBlocks("de"),
   });
 
   const [activeLang, setActiveLang] = useState<LangCode>("en");
@@ -193,38 +422,36 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
   const setMetaField = <K extends keyof typeof meta>(key: K, value: (typeof meta)[K]) =>
     setMeta((f) => ({ ...f, [key]: value }));
 
-  const setContent = (key: keyof LangContent, value: string) =>
-    setLangContent((prev) => ({ ...prev, [activeLang]: { ...prev[activeLang], [key]: value } }));
-
   const handleTitleChange = (v: string) => {
-    setContent("title", v);
+    setLangMeta((prev) => ({ ...prev, [activeLang]: { ...prev[activeLang], title: v } }));
     if (activeLang === "en" && !slugTouched) setMetaField("slug", slugify(v));
   };
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handleSubmit = async (e?: React.FormEvent) => {
+    e?.preventDefault();
     setError(null);
-    const enContent = langContent["en"];
-    if (!enContent.title.trim()) return setError("English title is required.");
-    if (!meta.slug.trim()) return setError("Slug is required.");
+    if (!langMeta.en.title.trim()) return setError("Englischer Titel ist erforderlich.");
+    if (!meta.slug.trim()) return setError("URL-Slug ist erforderlich.");
     setLoading(true);
 
     const translations: Record<string, LangContent> = {};
     for (const l of SUPPORTED_LANGS) {
       if (l.code === "en") continue;
-      const c = langContent[l.code];
-      if (c.title || c.short_description || c.content) {
-        translations[l.code] = c;
+      const m = langMeta[l.code];
+      const blocks = langBlocks[l.code];
+      const hasContent = m.title || blocks.some((b) => b.type !== "paragraph" || (b as Extract<Block, { type: "paragraph" }>).content);
+      if (hasContent) {
+        translations[l.code] = { title: m.title, short_description: m.short_description, content: blocksToString(blocks) };
       }
     }
 
     try {
       await onSave(
         {
-          title: enContent.title,
+          title: langMeta.en.title,
           slug: meta.slug,
-          short_description: enContent.short_description,
-          content: enContent.content,
+          short_description: langMeta.en.short_description,
+          content: blocksToString(langBlocks.en),
           image_url: meta.image_url,
           published_at: initial?.published_at ?? new Date().toISOString().slice(0, 10),
           author: initial?.author ?? "",
@@ -238,107 +465,103 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
     }
   };
 
-  const currentContent = langContent[activeLang];
-  const wordCount = currentContent.content.trim() ? currentContent.content.trim().split(/\s+/).length : 0;
-  const charCount = currentContent.content.length;
-
   const translationsForTabs = Object.fromEntries(
-    SUPPORTED_LANGS.filter((l) => l.code !== "en").map((l) => [l.code, langContent[l.code]])
+    SUPPORTED_LANGS.filter((l) => l.code !== "en").map((l) => [
+      l.code,
+      { title: langMeta[l.code].title, short_description: langMeta[l.code].short_description, content: blocksToString(langBlocks[l.code]) },
+    ])
   ) as Record<string, LangContent>;
+
+  const currentMeta = langMeta[activeLang];
+  const currentBlocks = langBlocks[activeLang];
+  const setCurrentBlocks = (blocks: Block[]) => setLangBlocks((prev) => ({ ...prev, [activeLang]: blocks }));
+
+  const blockCount = currentBlocks.length;
+  const wordCount = currentBlocks
+    .filter((b): b is Extract<Block, { type: "paragraph" | "heading" }> => ["paragraph", "heading"].includes(b.type))
+    .reduce((n, b) => n + b.content.trim().split(/\s+/).filter(Boolean).length, 0);
 
   return (
     <div>
-      {/* Header */}
       <div className="mb-8 flex items-center justify-between">
         <div className="flex items-center gap-3">
           <button onClick={onCancel} className="flex items-center gap-1.5 rounded-lg border border-white/10 px-3 py-1.5 text-sm text-white/40 hover:border-white/20 hover:text-white transition-all">
-            <ChevronLeft size={15} /> Back
+            <ChevronLeft size={15} /> Zurück
           </button>
           <span className="text-white/10">/</span>
           <h1 className="text-xl font-bold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>
-            {isNew ? "New Article" : "Edit Article"}
+            {isNew ? "Neuer Artikel" : "Artikel bearbeiten"}
           </h1>
-          {!isNew && (
-            <span className="rounded-full border border-yellow-500/20 bg-yellow-500/10 px-2.5 py-0.5 text-xs font-medium text-yellow-400">
-              Editing
-            </span>
-          )}
+          {!isNew && <span className="rounded-full border border-yellow-500/20 bg-yellow-500/10 px-2.5 py-0.5 text-xs font-medium text-yellow-400">Bearbeiten</span>}
         </div>
-        <button type="button" onClick={handleSubmit} disabled={loading} className="hidden sm:flex items-center gap-2 rounded-xl bg-green-500 px-5 py-2 text-sm font-semibold text-black hover:bg-green-400 disabled:opacity-60 transition-colors">
+        <button type="button" onClick={() => handleSubmit()} disabled={loading} className="hidden sm:flex items-center gap-2 rounded-xl bg-green-500 px-5 py-2 text-sm font-semibold text-black hover:bg-green-400 disabled:opacity-60 transition-colors">
           {loading ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
-          {isNew ? "Publish" : "Save changes"}
+          {isNew ? "Veröffentlichen" : "Speichern"}
         </button>
       </div>
 
       <form onSubmit={handleSubmit} className="grid gap-6 lg:grid-cols-3">
-        {/* Main content area */}
         <div className="flex flex-col gap-5 lg:col-span-2">
           {/* Language tabs */}
           <div className="flex items-center justify-between rounded-2xl border border-white/5 bg-white/[0.02] px-5 py-3.5">
             <div className="flex items-center gap-2 text-xs text-white/30">
               <Languages size={14} className="text-white/20" />
-              <span>Language</span>
+              <span>Sprache</span>
             </div>
             <LangTabs active={activeLang} onChange={setActiveLang} translations={translationsForTabs} />
           </div>
 
-          {/* Title card */}
+          {/* Title */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-6 shadow-sm">
             <div className="mb-3 flex items-center justify-between">
-              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Headline</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Überschrift</p>
               <span className="rounded-md bg-white/5 px-2 py-0.5 text-xs text-white/20">
                 {SUPPORTED_LANGS.find((l) => l.code === activeLang)?.name}
               </span>
             </div>
             <input
-              value={currentContent.title}
+              value={currentMeta.title}
               onChange={(e) => handleTitleChange(e.target.value)}
               placeholder={activeLang === "en" ? "Write an engaging headline…" : "Überschrift auf Deutsch…"}
               className="w-full rounded-xl border border-white/10 bg-white/5 px-4 py-3 text-lg font-semibold text-white outline-none placeholder-white/15 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20 transition-all"
             />
-            {activeLang !== "en" && !langContent["en"].title && (
-              <p className="mt-1.5 text-xs text-yellow-500/60">English title is required before publishing.</p>
-            )}
           </div>
 
-          {/* Description card */}
+          {/* Teaser */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] p-6 shadow-sm">
             <div className="mb-4 flex items-center justify-between">
               <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Teaser</p>
-              <span className="text-xs text-white/20">{currentContent.short_description.length} chars</span>
+              <span className="text-xs text-white/20">{currentMeta.short_description.length} Zeichen</span>
             </div>
-            <Textarea
-              value={currentContent.short_description}
-              onChange={(e) => setContent("short_description", e.target.value)}
+            <textarea
+              value={currentMeta.short_description}
+              onChange={(e) => setLangMeta((prev) => ({ ...prev, [activeLang]: { ...prev[activeLang], short_description: e.target.value } }))}
               rows={3}
               placeholder={activeLang === "en" ? "Short summary shown on the news list…" : "Kurze Zusammenfassung auf Deutsch…"}
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white outline-none placeholder-white/20 focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20 resize-y"
             />
           </div>
 
-          {/* Content card */}
+          {/* Block editor */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] shadow-sm overflow-hidden">
             <div className="flex items-center justify-between border-b border-white/5 px-6 py-3">
-              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Article body</p>
+              <div className="flex items-center gap-2">
+                <LayoutTemplate size={14} className="text-white/20" />
+                <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Inhalt</p>
+              </div>
               <div className="flex items-center gap-3 text-xs text-white/20">
-                <span>{wordCount} words</span>
+                <span>{blockCount} Blöcke</span>
                 <span className="text-white/10">·</span>
-                <span>{charCount} chars</span>
+                <span>{wordCount} Wörter</span>
               </div>
             </div>
             <div className="p-6">
-              <textarea
-                value={currentContent.content}
-                onChange={(e) => setContent("content", e.target.value)}
-                rows={20}
-                placeholder={activeLang === "en" ? "Write the full article here…" : "Vollständigen Artikel auf Deutsch schreiben…"}
-                className="w-full rounded-xl border border-white/8 bg-black/20 px-4 py-3 text-sm text-white/90 outline-none placeholder-white/15 focus:border-green-500/30 focus:ring-1 focus:ring-green-500/15 resize-y transition-all"
-                style={{ fontFamily: "'JetBrains Mono', 'Fira Code', monospace", lineHeight: "1.7" }}
-              />
+              <BlockEditor blocks={currentBlocks} onChange={setCurrentBlocks} />
             </div>
           </div>
         </div>
 
-        {/* Sidebar panels */}
+        {/* Sidebar */}
         <div className="flex flex-col gap-4 lg:sticky lg:top-24 lg:self-start">
           {error && (
             <div className="flex items-start gap-2.5 rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-300">
@@ -350,28 +573,22 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
           {/* Translations status */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden shadow-sm">
             <div className="border-b border-white/5 px-5 py-3.5">
-              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Translations</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Übersetzungen</p>
             </div>
             <div className="flex flex-col gap-2 p-5">
               {SUPPORTED_LANGS.map((l) => {
-                const c = langContent[l.code];
-                const filled = !!(c.title || c.content);
+                const m = langMeta[l.code];
+                const filled = !!(m.title || langBlocks[l.code].some((b) => b.type !== "paragraph" || (b as Extract<Block, { type: "paragraph" }>).content));
                 return (
-                  <button
-                    key={l.code}
-                    type="button"
-                    onClick={() => setActiveLang(l.code)}
-                    className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${
-                      activeLang === l.code ? "bg-white/8 text-white" : "text-white/40 hover:bg-white/5 hover:text-white/60"
-                    }`}
-                  >
+                  <button key={l.code} type="button" onClick={() => setActiveLang(l.code)}
+                    className={`flex items-center justify-between rounded-lg px-3 py-2 text-sm transition-colors ${activeLang === l.code ? "bg-white/8 text-white" : "text-white/40 hover:bg-white/5 hover:text-white/60"}`}>
                     <span className="font-medium">{l.name}</span>
                     {filled ? (
-                      <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-xs text-green-400">Done</span>
+                      <span className="rounded-full bg-green-500/15 px-2 py-0.5 text-xs text-green-400">Fertig</span>
                     ) : l.code === "en" ? (
-                      <span className="rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-500/70">Required</span>
+                      <span className="rounded-full bg-yellow-500/10 px-2 py-0.5 text-xs text-yellow-500/70">Pflicht</span>
                     ) : (
-                      <span className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-white/20">Missing</span>
+                      <span className="rounded-full bg-white/5 px-2 py-0.5 text-xs text-white/20">Fehlt</span>
                     )}
                   </button>
                 );
@@ -382,28 +599,24 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
           {/* Publish settings */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden shadow-sm">
             <div className="border-b border-white/5 px-5 py-3.5">
-              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Publish</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Veröffentlichen</p>
             </div>
             <div className="flex flex-col gap-4 p-5">
-              <Field label="URL slug *">
+              <Field label="URL Slug *">
                 <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
                   <span className="shrink-0 border-r border-white/10 bg-white/5 px-3 py-2 text-xs text-white/20">/news/</span>
                   <input
                     type="text"
                     value={meta.slug}
                     onChange={(e) => { setSlugTouched(true); setMetaField("slug", e.target.value); }}
-                    placeholder="my-article"
+                    placeholder="mein-artikel"
                     className="flex-1 bg-transparent py-2 px-3 text-sm text-white outline-none placeholder-white/20"
                   />
                 </div>
                 {meta.slug && (
-                  <a
-                    href={`/news/${meta.slug}`}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="flex items-center gap-1 text-xs text-white/20 hover:text-green-400 transition-colors"
-                  >
-                    <ExternalLink size={11} /> Preview URL
+                  <a href={`/news/${meta.slug}`} target="_blank" rel="noopener noreferrer"
+                    className="flex items-center gap-1 text-xs text-white/20 hover:text-green-400 transition-colors">
+                    <ExternalLink size={11} /> Vorschau-URL
                   </a>
                 )}
               </Field>
@@ -413,35 +626,26 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
           {/* Cover image */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.02] overflow-hidden shadow-sm">
             <div className="border-b border-white/5 px-5 py-3.5">
-              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Cover image</p>
+              <p className="text-xs font-semibold uppercase tracking-wider text-white/25">Titelbild</p>
             </div>
             <div className="p-5">
               {meta.image_url && !imgError ? (
                 <div className="mb-4 group relative overflow-hidden rounded-xl border border-white/5">
                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={meta.image_url}
-                    alt="Preview"
-                    onError={() => setImgError(true)}
-                    className="h-36 w-full object-cover"
-                  />
+                  <img src={meta.image_url} alt="Preview" onError={() => setImgError(true)} className="h-36 w-full object-cover" />
                   <div className="absolute inset-0 flex items-center justify-center bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity">
-                    <button
-                      type="button"
-                      onClick={() => { setMetaField("image_url", null); setImgError(false); }}
-                      className="flex items-center gap-1.5 rounded-lg bg-red-500/80 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500 transition-colors"
-                    >
-                      <X size={12} /> Remove
+                    <button type="button" onClick={() => { setMetaField("image_url", null); setImgError(false); }}
+                      className="flex items-center gap-1.5 rounded-lg bg-red-500/80 px-3 py-1.5 text-xs font-medium text-white hover:bg-red-500 transition-colors">
+                      <X size={12} /> Entfernen
                     </button>
                   </div>
                 </div>
               ) : imgError ? (
                 <div className="mb-4 flex h-20 items-center justify-center gap-2 rounded-xl border border-red-500/20 bg-red-500/5 text-xs text-red-400/60">
-                  <AlertCircle size={13} /> Could not load image
+                  <AlertCircle size={13} /> Bild konnte nicht geladen werden
                 </div>
               ) : null}
-
-              <Field label="Image URL">
+              <Field label="Bild-URL">
                 <div className="flex items-center overflow-hidden rounded-lg border border-white/10 bg-white/5 focus-within:border-green-500/40 focus-within:ring-1 focus-within:ring-green-500/20 transition-all">
                   <LinkIcon size={13} className="ml-3 shrink-0 text-white/20" />
                   <input
@@ -461,14 +665,13 @@ function Editor({ initial, onSave, onCancel }: { initial: NewsItem | null; onSav
             </div>
           </div>
 
-          {/* Action buttons */}
           <div className="flex flex-col gap-2">
             <button type="submit" disabled={loading} className="flex items-center justify-center gap-2 rounded-xl bg-green-500 py-3 text-sm font-semibold text-black hover:bg-green-400 disabled:opacity-60 transition-colors shadow-lg shadow-green-500/10">
               {loading ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
-              {isNew ? "Publish article" : "Save changes"}
+              {isNew ? "Artikel veröffentlichen" : "Änderungen speichern"}
             </button>
             <button type="button" onClick={onCancel} className="flex items-center justify-center gap-2 rounded-xl border border-white/8 py-2.5 text-sm text-white/40 hover:bg-white/5 hover:text-white/70 transition-colors">
-              <X size={14} /> Discard
+              <X size={14} /> Verwerfen
             </button>
           </div>
         </div>
@@ -516,17 +719,15 @@ function NewsRow({ item, onEdit, onDelete }: { item: NewsItem; onEdit: (i: NewsI
         </div>
       </td>
       <td className="px-3 py-3 whitespace-nowrap">
-        <div className="flex items-center gap-1">
-          <span className="flex items-center gap-1 text-xs text-white/25">
-            <Languages size={11} />
-            {1 + langCount}/{SUPPORTED_LANGS.length}
-          </span>
-        </div>
+        <span className="flex items-center gap-1 text-xs text-white/25">
+          <Languages size={11} />
+          {1 + langCount}/{SUPPORTED_LANGS.length}
+        </span>
       </td>
       <td className="py-3 pl-3 pr-4">
         <div className="flex items-center gap-1">
           <button onClick={() => onEdit(item)} className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 hover:bg-white/5 hover:text-white transition-colors">
-            <Pencil size={12} /> Edit
+            <Pencil size={12} /> Bearbeiten
           </button>
           <a href={`/news/${item.slug}`} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 hover:bg-white/5 hover:text-white transition-colors">
             <ExternalLink size={12} />
@@ -571,10 +772,10 @@ function NewsDashboardContent() {
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(payload),
     });
-    if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.error ?? "Failed to save"); }
+    if (!res.ok) { const e = await res.json().catch(() => ({})); throw new Error(e.error ?? "Speichern fehlgeschlagen"); }
     await load();
     setView("list"); setEditing(null);
-    showToast(id ? "Article updated." : "Article published.");
+    showToast(id ? "Artikel aktualisiert." : "Artikel veröffentlicht.");
   };
 
   const handleDelete = async () => {
@@ -582,7 +783,7 @@ function NewsDashboardContent() {
     setDeleteLoading(true);
     try {
       await fetch(`/api/dashboard/news/${deleteTarget.id}`, { method: "DELETE" });
-      await load(); showToast("Article deleted.");
+      await load(); showToast("Artikel gelöscht.");
     } finally { setDeleteLoading(false); setDeleteTarget(null); }
   };
 
@@ -608,18 +809,18 @@ function NewsDashboardContent() {
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
           <h1 className="text-2xl font-bold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>News</h1>
-          <p className="mt-0.5 text-sm text-white/40">{items.length} articles</p>
+          <p className="mt-0.5 text-sm text-white/40">{items.length} Artikel</p>
         </div>
         <div className="flex items-center gap-2">
           <div className="relative">
             <Search size={15} className="absolute left-3 top-1/2 -translate-y-1/2 text-white/30" />
-            <input type="text" placeholder="Search…" value={search} onChange={(e) => setSearch(e.target.value)} className="h-9 w-full rounded-lg border border-white/10 bg-white/5 pl-9 pr-4 text-sm text-white placeholder-white/30 outline-none focus:border-green-500/40 sm:w-56" />
+            <input type="text" placeholder="Suchen…" value={search} onChange={(e) => setSearch(e.target.value)} className="h-9 w-full rounded-lg border border-white/10 bg-white/5 pl-9 pr-4 text-sm text-white placeholder-white/30 outline-none focus:border-green-500/40 sm:w-56" />
           </div>
           <button onClick={load} disabled={loading} className="flex h-9 items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 text-white/60 hover:bg-white/10 hover:text-white disabled:opacity-50 transition-colors">
             <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
           </button>
           <button onClick={() => { setEditing(null); setView("editor"); }} className="flex h-9 items-center gap-2 rounded-lg bg-green-500 px-4 text-sm font-semibold text-black hover:bg-green-400 transition-colors">
-            <Plus size={15} /> New article
+            <Plus size={15} /> Neuer Artikel
           </button>
         </div>
       </div>
@@ -632,9 +833,9 @@ function NewsDashboardContent() {
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16">
             <Newspaper size={32} className="text-white/10" />
-            <p className="text-sm text-white/30">No articles yet.</p>
+            <p className="text-sm text-white/30">Noch keine Artikel.</p>
             <button onClick={() => { setEditing(null); setView("editor"); }} className="flex items-center gap-2 rounded-lg bg-green-500/10 px-4 py-2 text-sm font-medium text-green-400 hover:bg-green-500/20 transition-colors">
-              <Plus size={14} /> Write first article
+              <Plus size={14} /> Ersten Artikel schreiben
             </button>
           </div>
         ) : (
@@ -642,12 +843,12 @@ function NewsDashboardContent() {
             <table className="w-full min-w-[880px]">
               <thead>
                 <tr className="border-b border-white/5">
-                  <th className="py-3 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Article</th>
-                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Description</th>
-                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Author</th>
-                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Date</th>
-                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Langs</th>
-                  <th className="py-3 pl-3 pr-4 text-left text-xs font-medium uppercase tracking-wider text-white/30">Actions</th>
+                  <th className="py-3 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Artikel</th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Beschreibung</th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Autor</th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Datum</th>
+                  <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">Sprachen</th>
+                  <th className="py-3 pl-3 pr-4 text-left text-xs font-medium uppercase tracking-wider text-white/30">Aktionen</th>
                 </tr>
               </thead>
               <tbody>

--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -56,25 +56,151 @@ function estimateReadTime(text: string): number {
   return Math.max(1, Math.round(words / 200));
 }
 
-function parseMarkdownLinks(text: string) {
+/* ── Block types (mirrored from dashboard) ─────────────────────────── */
+type Block =
+  | { id: string; type: "paragraph"; content: string }
+  | { id: string; type: "heading"; level: 2 | 3; content: string }
+  | { id: string; type: "youtube"; url: string }
+  | { id: string; type: "image"; url: string; caption: string }
+  | { id: string; type: "callout"; variant: "info" | "warning" | "tip" | "success"; title: string; content: string }
+  | { id: string; type: "divider" };
+
+function parseContent(content: string): Block[] | null {
+  try {
+    const parsed = JSON.parse(content);
+    if (Array.isArray(parsed) && parsed.length > 0 && parsed[0]?.type) return parsed as Block[];
+  } catch { /* not JSON */ }
+  return null;
+}
+
+function extractYoutubeId(url: string): string | null {
+  const m = url.match(/(?:youtube\.com\/watch\?v=|youtu\.be\/|youtube\.com\/shorts\/)([a-zA-Z0-9_-]{11})/);
+  return m ? m[1] : null;
+}
+
+const CALLOUT_STYLES: Record<string, { border: string; bg: string; title: string; icon: string }> = {
+  info:    { border: "border-blue-500/30",    bg: "bg-blue-500/[0.06]",    title: "text-blue-400",    icon: "ℹ" },
+  tip:     { border: "border-green-500/30",   bg: "bg-green-500/[0.06]",   title: "text-green-400",   icon: "💡" },
+  warning: { border: "border-yellow-500/30",  bg: "bg-yellow-500/[0.06]",  title: "text-yellow-400",  icon: "⚠" },
+  success: { border: "border-emerald-500/30", bg: "bg-emerald-500/[0.06]", title: "text-emerald-400", icon: "✓" },
+};
+
+function InlineText({ text }: { text: string }) {
   const parts: Array<{ type: string; content?: string; text?: string; url?: string }> = [];
   const linkRegex = /\[([^\]]+)\]\(([^)]+)\)/g;
   let lastIndex = 0;
   let match;
-
   while ((match = linkRegex.exec(text)) !== null) {
-    if (match.index > lastIndex) {
-      parts.push({ type: "text", content: text.substring(lastIndex, match.index) });
-    }
+    if (match.index > lastIndex) parts.push({ type: "text", content: text.substring(lastIndex, match.index) });
     parts.push({ type: "link", text: match[1], url: match[2] });
     lastIndex = match.index + match[0].length;
   }
+  if (lastIndex < text.length) parts.push({ type: "text", content: text.substring(lastIndex) });
+  if (parts.length === 0) parts.push({ type: "text", content: text });
 
-  if (lastIndex < text.length) {
-    parts.push({ type: "text", content: text.substring(lastIndex) });
-  }
+  return (
+    <>
+      {parts.map((part, i) =>
+        part.type === "link" && part.url && part.text ? (
+          <a key={i} href={part.url} target="_blank" rel="noopener noreferrer"
+            className="text-green-400 underline decoration-green-500/30 underline-offset-2 transition-colors hover:text-green-300 hover:decoration-green-400/60">
+            {part.text}
+          </a>
+        ) : (
+          <span key={i}>{part.content}</span>
+        )
+      )}
+    </>
+  );
+}
 
-  return parts.length > 0 ? parts : [{ type: "text", content: text }];
+function BlockRenderer({ blocks }: { blocks: Block[] }) {
+  return (
+    <div className="flex flex-col gap-4">
+      {blocks.map((block, i) => {
+        if (block.type === "paragraph") {
+          if (!block.content.trim()) return null;
+          return (
+            <p key={i} className="leading-relaxed text-white/65" style={{ fontFamily: "'DM Sans', sans-serif", fontSize: "0.9375rem" }}>
+              <InlineText text={block.content} />
+            </p>
+          );
+        }
+        if (block.type === "heading") {
+          const Tag = `h${block.level}` as "h2" | "h3";
+          return (
+            <Tag key={i} className={`font-bold text-white ${block.level === 2 ? "text-xl mt-4" : "text-base mt-2"}`} style={{ fontFamily: "'Syne', sans-serif" }}>
+              {block.content}
+            </Tag>
+          );
+        }
+        if (block.type === "youtube") {
+          const vid = extractYoutubeId(block.url);
+          if (!vid) return null;
+          return (
+            <div key={i} className="overflow-hidden rounded-xl border border-white/5">
+              <div className="relative aspect-video w-full bg-black">
+                <iframe
+                  src={`https://www.youtube.com/embed/${vid}`}
+                  className="absolute inset-0 h-full w-full"
+                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+                  allowFullScreen
+                  title="YouTube video"
+                />
+              </div>
+            </div>
+          );
+        }
+        if (block.type === "image") {
+          return (
+            <figure key={i} className="overflow-hidden rounded-xl border border-white/5">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={block.url} alt={block.caption || ""} className="w-full object-cover" />
+              {block.caption && (
+                <figcaption className="px-4 py-2 text-center text-xs text-white/30" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+                  {block.caption}
+                </figcaption>
+              )}
+            </figure>
+          );
+        }
+        if (block.type === "callout") {
+          const s = CALLOUT_STYLES[block.variant] ?? CALLOUT_STYLES.info;
+          return (
+            <div key={i} className={`rounded-xl border ${s.border} ${s.bg} px-5 py-4`}>
+              {block.title && (
+                <p className={`mb-1.5 flex items-center gap-1.5 text-sm font-semibold ${s.title}`} style={{ fontFamily: "'Syne', sans-serif" }}>
+                  <span>{s.icon}</span> {block.title}
+                </p>
+              )}
+              <p className="text-sm leading-relaxed text-white/60" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+                {block.content}
+              </p>
+            </div>
+          );
+        }
+        if (block.type === "divider") {
+          return <hr key={i} className="border-white/8" />;
+        }
+        return null;
+      })}
+    </div>
+  );
+}
+
+function LegacyTextRenderer({ content }: { content: string }) {
+  const lines = content.split("\n");
+  return (
+    <div className="flex flex-col gap-1" style={{ fontFamily: "'DM Sans', sans-serif", fontSize: "0.9375rem" }}>
+      {lines.map((line, i) =>
+        line.trim() === "" ? <div key={i} className="h-3" /> : (
+          <p key={i} className="leading-relaxed text-white/65">
+            <InlineText text={line} />
+          </p>
+        )
+      )}
+    </div>
+  );
 }
 
 function toISODate(dateStr: string): string | undefined {
@@ -163,7 +289,7 @@ export default async function NewsPage({ params }: PageProps) {
   }
 
   const resolved = resolveContent(item, locale);
-  const textLines = resolved.content.split("\n");
+  const blocks = parseContent(resolved.content);
   const readTime = estimateReadTime(resolved.content);
 
   const canonicalUrl =
@@ -308,37 +434,7 @@ export default async function NewsPage({ params }: PageProps) {
 
           {/* Article body */}
           <div className="rounded-2xl border border-white/5 bg-white/[0.03] p-6 md:p-8">
-            <div
-              className="leading-relaxed text-white/65"
-              style={{ fontFamily: "'DM Sans', sans-serif", fontSize: "0.9375rem" }}
-            >
-              {textLines.map((line, lineIndex) => {
-                if (line.trim() === "") {
-                  return <div key={lineIndex} className="h-4" />;
-                }
-                const parts = parseMarkdownLinks(line);
-                return (
-                  <p key={lineIndex} className="mb-2">
-                    {parts.map((part, partIndex) => {
-                      if (part.type === "link" && part.url && part.text) {
-                        return (
-                          <a
-                            key={partIndex}
-                            href={part.url}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                            className="text-green-400 underline decoration-green-500/30 underline-offset-2 transition-colors duration-200 hover:text-green-300 hover:decoration-green-400/60"
-                          >
-                            {part.text}
-                          </a>
-                        );
-                      }
-                      return <span key={partIndex}>{part.content}</span>;
-                    })}
-                  </p>
-                );
-              })}
-            </div>
+            {blocks ? <BlockRenderer blocks={blocks} /> : <LegacyTextRenderer content={resolved.content} />}
           </div>
 
           {/* Author card */}

--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Link from "next/link";
+import YoutubeEmbed from "@/components/youtube-embed";
 import TopPage from "@/components/page/top";
 import { notFound } from "next/navigation";
 import type { Metadata } from "next";
@@ -137,19 +138,7 @@ function BlockRenderer({ blocks }: { blocks: Block[] }) {
         if (block.type === "youtube") {
           const vid = extractYoutubeId(block.url);
           if (!vid) return null;
-          return (
-            <div key={i} className="overflow-hidden rounded-xl border border-white/5">
-              <div className="relative aspect-video w-full bg-black">
-                <iframe
-                  src={`https://www.youtube.com/embed/${vid}`}
-                  className="absolute inset-0 h-full w-full"
-                  allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                  allowFullScreen
-                  title="YouTube video"
-                />
-              </div>
-            </div>
-          );
+          return <YoutubeEmbed key={i} videoId={vid} />;
         }
         if (block.type === "image") {
           return (

--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -56,7 +56,7 @@ function estimateReadTime(text: string): number {
   return Math.max(1, Math.round(words / 200));
 }
 
-/* ── Block types (mirrored from dashboard) ─────────────────────────── */
+/* --- Block types (mirrored from dashboard) --- */
 type Block =
   | { id: string; type: "paragraph"; content: string }
   | { id: string; type: "heading"; level: 2 | 3; content: string }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -41,7 +41,7 @@ function PrivacyEN() {
   return (
     <>
       <h1 className="text-2xl font-bold mb-2">Privacy Policy</h1>
-      <p className="text-gray-400 mb-8 text-sm">Last Updated: March 2026</p>
+      <p className="text-gray-400 mb-8 text-sm">Last Updated: July 2026</p>
 
       <h2 className="text-xl font-semibold mt-8 mb-4">1. Controller (Verantwortlicher)</h2>
       <p>
@@ -132,6 +132,28 @@ function PrivacyEN() {
         46(2)(c) GDPR). Discord&apos;s privacy policy is available at:{" "}
         <a href="https://discord.com/privacy" className="text-green-400 hover:text-green-300">
           https://discord.com/privacy
+        </a>
+      </p>
+
+      <h3 id="youtube" className="text-lg font-semibold mt-4 mb-2">3.7 YouTube Embedded Videos</h3>
+      <p>
+        Some pages on this website may embed YouTube videos. YouTube is a service of Google Ireland Limited,
+        Gordon House, Barrow Street, Dublin 4, Ireland (&quot;Google&quot;). Embedded videos are only loaded after
+        you explicitly consent by clicking the &quot;Load video &amp; accept cookies&quot; button shown in place of the
+        video player.
+      </p>
+      <p className="mt-2">
+        Once you consent, the video is loaded via the privacy-enhanced domain{" "}
+        <strong>youtube-nocookie.com</strong>, which reduces — but does not eliminate — data sent to Google.
+        Google may still set cookies and receive your IP address, browser information, and the URL of the
+        page you are visiting. This data may be transferred to Google servers in the USA.
+      </p>
+      <p className="mt-2">
+        The legal basis for this processing is your consent (Art. 6(1)(a) GDPR). You can withdraw your
+        consent at any time via the Cookie Settings button in the footer. Google&apos;s privacy policy is
+        available at:{" "}
+        <a href="https://policies.google.com/privacy" className="text-green-400 hover:text-green-300">
+          https://policies.google.com/privacy
         </a>
       </p>
 
@@ -242,7 +264,7 @@ function PrivacyEN() {
         </a>
       </p>
 
-      <p className="mt-10 text-gray-400 text-sm">Last Updated: March 2026</p>
+      <p className="mt-10 text-gray-400 text-sm">Last Updated: July 2026</p>
     </>
   );
 }
@@ -251,7 +273,7 @@ function PrivacyDE() {
   return (
     <>
       <h1 className="text-2xl font-bold mb-2">Datenschutzerklärung</h1>
-      <p className="text-gray-400 mb-8 text-sm">Zuletzt aktualisiert: März 2026</p>
+      <p className="text-gray-400 mb-8 text-sm">Zuletzt aktualisiert: Juli 2026</p>
 
       <h2 className="text-xl font-semibold mt-8 mb-4">1. Verantwortlicher</h2>
       <p>
@@ -345,6 +367,29 @@ function PrivacyDE() {
         verfügbar unter:{" "}
         <a href="https://discord.com/privacy" className="text-green-400 hover:text-green-300">
           https://discord.com/privacy
+        </a>
+      </p>
+
+      <h3 id="youtube" className="text-lg font-semibold mt-4 mb-2">3.7 Eingebettete YouTube-Videos</h3>
+      <p>
+        Einige Seiten dieser Website können YouTube-Videos einbetten. YouTube ist ein Dienst der Google Ireland
+        Limited, Gordon House, Barrow Street, Dublin 4, Irland („Google"). Eingebettete Videos werden erst
+        geladen, nachdem du explizit durch Klicken auf den Button „Video laden &amp; Cookies akzeptieren" im
+        Videoplatzhalter zugestimmt hast.
+      </p>
+      <p className="mt-2">
+        Nach deiner Zustimmung wird das Video über die datenschutzfreundlichere Domain{" "}
+        <strong>youtube-nocookie.com</strong> geladen, was die Datenweitergabe an Google reduziert – aber
+        nicht vollständig verhindert. Google kann weiterhin Cookies setzen und deine IP-Adresse,
+        Browser-Informationen sowie die URL der aufgerufenen Seite erhalten. Diese Daten können auf
+        Google-Server in den USA übertragen werden.
+      </p>
+      <p className="mt-2">
+        Rechtsgrundlage dieser Verarbeitung ist deine Einwilligung (Art. 6 Abs. 1 lit. a DSGVO). Du kannst
+        deine Einwilligung jederzeit über den Button „Cookie-Einstellungen" im Footer widerrufen. Die
+        Datenschutzerklärung von Google ist verfügbar unter:{" "}
+        <a href="https://policies.google.com/privacy" className="text-green-400 hover:text-green-300">
+          https://policies.google.com/privacy
         </a>
       </p>
 
@@ -456,7 +501,7 @@ function PrivacyDE() {
         </a>
       </p>
 
-      <p className="mt-10 text-gray-400 text-sm">Zuletzt aktualisiert: März 2026</p>
+      <p className="mt-10 text-gray-400 text-sm">Zuletzt aktualisiert: Juli 2026</p>
     </>
   );
 }

--- a/src/app/privacy/page.tsx
+++ b/src/app/privacy/page.tsx
@@ -157,6 +157,28 @@ function PrivacyEN() {
         </a>
       </p>
 
+      <h3 id="twitch" className="text-lg font-semibold mt-4 mb-2">3.8 Twitch Embedded Streams</h3>
+      <p>
+        The Creators page on this website may embed live Twitch streams. Twitch is a service of Twitch
+        Interactive, Inc., a subsidiary of Amazon.com, Inc., 350 Bush Street, 2nd Floor, San Francisco, CA
+        94104, USA (&quot;Twitch&quot;). Embedded streams are only loaded after you explicitly consent by clicking
+        the &quot;Load stream &amp; accept cookies&quot; button shown in place of the player.
+      </p>
+      <p className="mt-2">
+        Once you consent, the stream is embedded via an iframe connecting to{" "}
+        <strong>player.twitch.tv</strong>. Twitch and Amazon may set cookies and receive your IP address,
+        browser information, and the URL of the page you are visiting. This data may be transferred to
+        servers in the USA.
+      </p>
+      <p className="mt-2">
+        The legal basis for this processing is your consent (Art. 6(1)(a) GDPR). You can withdraw your
+        consent at any time via the Cookie Settings button in the footer. Twitch&apos;s privacy policy is
+        available at:{" "}
+        <a href="https://www.twitch.tv/p/legal/privacy-notice/" className="text-green-400 hover:text-green-300">
+          https://www.twitch.tv/p/legal/privacy-notice/
+        </a>
+      </p>
+
       <h2 className="text-xl font-semibold mt-8 mb-4">4. Legal Basis for Processing</h2>
       <p>We process your personal data on the following legal bases under the GDPR:</p>
       <ul className="list-disc pl-6 mt-2 mb-4 space-y-2">
@@ -390,6 +412,29 @@ function PrivacyDE() {
         Datenschutzerklärung von Google ist verfügbar unter:{" "}
         <a href="https://policies.google.com/privacy" className="text-green-400 hover:text-green-300">
           https://policies.google.com/privacy
+        </a>
+      </p>
+
+      <h3 id="twitch" className="text-lg font-semibold mt-4 mb-2">3.8 Eingebettete Twitch-Streams</h3>
+      <p>
+        Auf der Creators-Seite dieser Website können Live-Streams von Twitch eingebettet werden. Twitch ist
+        ein Dienst der Twitch Interactive, Inc., einem Tochterunternehmen der Amazon.com, Inc., 350 Bush
+        Street, 2nd Floor, San Francisco, CA 94104, USA („Twitch"). Eingebettete Streams werden erst
+        geladen, nachdem du explizit durch Klicken auf den Button „Stream laden &amp; Cookies akzeptieren"
+        im Player-Platzhalter zugestimmt hast.
+      </p>
+      <p className="mt-2">
+        Nach deiner Zustimmung wird der Stream über ein iframe von{" "}
+        <strong>player.twitch.tv</strong> eingebunden. Twitch und Amazon können dabei Cookies setzen und
+        deine IP-Adresse, Browser-Informationen sowie die URL der aufgerufenen Seite erhalten. Diese
+        Daten können auf Server in den USA übertragen werden.
+      </p>
+      <p className="mt-2">
+        Rechtsgrundlage dieser Verarbeitung ist deine Einwilligung (Art. 6 Abs. 1 lit. a DSGVO). Du kannst
+        deine Einwilligung jederzeit über den Button „Cookie-Einstellungen" im Footer widerrufen. Die
+        Datenschutzerklärung von Twitch ist verfügbar unter:{" "}
+        <a href="https://www.twitch.tv/p/legal/privacy-notice/" className="text-green-400 hover:text-green-300">
+          https://www.twitch.tv/p/legal/privacy-notice/
         </a>
       </p>
 

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -35,9 +35,10 @@ export default function CookieConsent() {
     localStorage.setItem("cookie-consent", "accepted");
     window.localStorage.setItem(
       "va-preferences",
-      JSON.stringify({ analytics: true, youtube: true }),
+      JSON.stringify({ analytics: true, youtube: true, twitch: true }),
     );
     window.dispatchEvent(new Event("youtube-consent-changed"));
+    window.dispatchEvent(new Event("twitch-consent-changed"));
     dismissBanner();
   };
 
@@ -45,9 +46,10 @@ export default function CookieConsent() {
     localStorage.setItem("cookie-consent", "declined");
     window.localStorage.setItem(
       "va-preferences",
-      JSON.stringify({ analytics: false, youtube: false }),
+      JSON.stringify({ analytics: false, youtube: false, twitch: false }),
     );
     window.dispatchEvent(new Event("youtube-consent-changed"));
+    window.dispatchEvent(new Event("twitch-consent-changed"));
     dismissBanner();
   };
 

--- a/src/components/cookie-consent.tsx
+++ b/src/components/cookie-consent.tsx
@@ -35,8 +35,9 @@ export default function CookieConsent() {
     localStorage.setItem("cookie-consent", "accepted");
     window.localStorage.setItem(
       "va-preferences",
-      JSON.stringify({ analytics: true }),
+      JSON.stringify({ analytics: true, youtube: true }),
     );
+    window.dispatchEvent(new Event("youtube-consent-changed"));
     dismissBanner();
   };
 
@@ -44,8 +45,9 @@ export default function CookieConsent() {
     localStorage.setItem("cookie-consent", "declined");
     window.localStorage.setItem(
       "va-preferences",
-      JSON.stringify({ analytics: false }),
+      JSON.stringify({ analytics: false, youtube: false }),
     );
+    window.dispatchEvent(new Event("youtube-consent-changed"));
     dismissBanner();
   };
 

--- a/src/components/cookie-settings.tsx
+++ b/src/components/cookie-settings.tsx
@@ -17,10 +17,14 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
   const t = useTranslations();
   const { preferences, updatePreferences, resetPreferences } = useAnalytics();
   const [analyticsEnabled, setAnalyticsEnabled] = useState(preferences.analytics);
+  const [youtubeEnabled, setYoutubeEnabled] = useState(preferences.youtube);
 
   useEffect(() => {
-    if (isOpen) setAnalyticsEnabled(preferences.analytics);
-  }, [isOpen, preferences.analytics]);
+    if (isOpen) {
+      setAnalyticsEnabled(preferences.analytics);
+      setYoutubeEnabled(preferences.youtube);
+    }
+  }, [isOpen, preferences.analytics, preferences.youtube]);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -43,14 +47,16 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
   if (!isOpen) return null;
 
   const handleSave = () => {
-    updatePreferences({ analytics: analyticsEnabled });
-    localStorage.setItem("cookie-consent", analyticsEnabled ? "accepted" : "custom");
+    updatePreferences({ analytics: analyticsEnabled, youtube: youtubeEnabled });
+    localStorage.setItem("cookie-consent", (analyticsEnabled || youtubeEnabled) ? "custom" : "declined");
+    window.dispatchEvent(new Event("youtube-consent-changed"));
     onClose();
   };
 
   const handleReset = () => {
     resetPreferences();
     setAnalyticsEnabled(false);
+    setYoutubeEnabled(false);
     onClose();
   };
 
@@ -129,6 +135,24 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
                 id="analytics"
                 checked={analyticsEnabled}
                 onCheckedChange={setAnalyticsEnabled}
+              />
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4 transition-colors hover:border-gray-700">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <Label htmlFor="youtube" className="text-base font-medium text-white">
+                  {t.cookieSettings.youtubeLabel}
+                </Label>
+                <p className="mt-1 text-sm text-gray-400">
+                  {t.cookieSettings.youtubeDesc}
+                </p>
+              </div>
+              <Switch
+                id="youtube"
+                checked={youtubeEnabled}
+                onCheckedChange={setYoutubeEnabled}
               />
             </div>
           </div>

--- a/src/components/cookie-settings.tsx
+++ b/src/components/cookie-settings.tsx
@@ -18,13 +18,15 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
   const { preferences, updatePreferences, resetPreferences } = useAnalytics();
   const [analyticsEnabled, setAnalyticsEnabled] = useState(preferences.analytics);
   const [youtubeEnabled, setYoutubeEnabled] = useState(preferences.youtube);
+  const [twitchEnabled, setTwitchEnabled] = useState(preferences.twitch);
 
   useEffect(() => {
     if (isOpen) {
       setAnalyticsEnabled(preferences.analytics);
       setYoutubeEnabled(preferences.youtube);
+      setTwitchEnabled(preferences.twitch);
     }
-  }, [isOpen, preferences.analytics, preferences.youtube]);
+  }, [isOpen, preferences.analytics, preferences.youtube, preferences.twitch]);
 
   const handleClose = useCallback(() => {
     onClose();
@@ -47,9 +49,10 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
   if (!isOpen) return null;
 
   const handleSave = () => {
-    updatePreferences({ analytics: analyticsEnabled, youtube: youtubeEnabled });
-    localStorage.setItem("cookie-consent", (analyticsEnabled || youtubeEnabled) ? "custom" : "declined");
+    updatePreferences({ analytics: analyticsEnabled, youtube: youtubeEnabled, twitch: twitchEnabled });
+    localStorage.setItem("cookie-consent", (analyticsEnabled || youtubeEnabled || twitchEnabled) ? "custom" : "declined");
     window.dispatchEvent(new Event("youtube-consent-changed"));
+    window.dispatchEvent(new Event("twitch-consent-changed"));
     onClose();
   };
 
@@ -57,6 +60,7 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
     resetPreferences();
     setAnalyticsEnabled(false);
     setYoutubeEnabled(false);
+    setTwitchEnabled(false);
     onClose();
   };
 
@@ -153,6 +157,24 @@ export default function CookieSettings({ isOpen, onClose }: CookieSettingsProps)
                 id="youtube"
                 checked={youtubeEnabled}
                 onCheckedChange={setYoutubeEnabled}
+              />
+            </div>
+          </div>
+
+          <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4 transition-colors hover:border-gray-700">
+            <div className="flex items-start justify-between gap-4">
+              <div className="min-w-0">
+                <Label htmlFor="twitch" className="text-base font-medium text-white">
+                  {t.cookieSettings.twitchLabel}
+                </Label>
+                <p className="mt-1 text-sm text-gray-400">
+                  {t.cookieSettings.twitchDesc}
+                </p>
+              </div>
+              <Switch
+                id="twitch"
+                checked={twitchEnabled}
+                onCheckedChange={setTwitchEnabled}
               />
             </div>
           </div>

--- a/src/components/page/creators.tsx
+++ b/src/components/page/creators.tsx
@@ -3,6 +3,7 @@ import React, { useState, useEffect } from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { useTranslations } from "@/lib/i18n/LanguageProvider";
+import TwitchEmbed from "@/components/twitch-embed";
 import {
   FaYoutube,
   FaTwitch,
@@ -159,21 +160,20 @@ export default function Creators({ initialCreators, initialFollowers, initialLiv
             <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
               {liveCreators.map((creator, index) => {
                 const live = liveStatus[creator.Name];
-                const embedUrl = live ? getStreamEmbedUrl(creator, live) : null;
+                const firstPlatform = creator.Platforms?.[0];
+                const platformType = firstPlatform?.Icons?.toLowerCase();
+                const twitchChannel = platformType === "twitch"
+                  ? firstPlatform?.Link?.match(/twitch\.tv\/([^\/\?]+)/i)?.[1] ?? null
+                  : null;
 
                 return (
                   <div
                     key={`live-${index}`}
                     className="rounded-lg bg-white/10 overflow-hidden transition-transform duration-300 hover:scale-105"
                   >
-                    {embedUrl ? (
-                      <div className="aspect-video bg-black relative">
-                        <iframe
-                          src={embedUrl}
-                          className="w-full h-full"
-                          allowFullScreen
-                          frameBorder="0"
-                        ></iframe>
+                    {twitchChannel ? (
+                      <div className="aspect-video bg-black relative overflow-hidden">
+                        <TwitchEmbed channel={twitchChannel} />
                       </div>
                     ) : (
                       <div className="aspect-video bg-gradient-to-br from-red-900/50 to-purple-900/50 flex items-center justify-center">

--- a/src/components/twitch-embed.tsx
+++ b/src/components/twitch-embed.tsx
@@ -1,0 +1,97 @@
+"use client";
+import { useState, useEffect } from "react";
+import { FaTwitch } from "react-icons/fa";
+import { useTranslations } from "@/lib/i18n/LanguageProvider";
+
+function getTwitchConsent(): boolean {
+  try {
+    const prefs = localStorage.getItem("va-preferences");
+    if (!prefs) return false;
+    return !!JSON.parse(prefs).twitch;
+  } catch {
+    return false;
+  }
+}
+
+function saveTwitchConsent() {
+  try {
+    const prefs = localStorage.getItem("va-preferences");
+    let p: Record<string, boolean> = {};
+    if (prefs) p = JSON.parse(prefs);
+    p.twitch = true;
+    localStorage.setItem("va-preferences", JSON.stringify(p));
+    if (!localStorage.getItem("cookie-consent")) {
+      localStorage.setItem("cookie-consent", "custom");
+    }
+    window.dispatchEvent(new Event("twitch-consent-changed"));
+  } catch {}
+}
+
+export default function TwitchEmbed({ channel }: { channel: string }) {
+  const t = useTranslations();
+  const [accepted, setAccepted] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setAccepted(getTwitchConsent());
+    const handler = () => setAccepted(getTwitchConsent());
+    window.addEventListener("twitch-consent-changed", handler);
+    return () => window.removeEventListener("twitch-consent-changed", handler);
+  }, []);
+
+  const accept = () => {
+    saveTwitchConsent();
+    setAccepted(true);
+  };
+
+  const hostname = typeof window !== "undefined" ? window.location.hostname : "onthepixel.net";
+  const embedUrl = `https://player.twitch.tv/?channel=${channel}&parent=${hostname}&autoplay=false`;
+
+  if (accepted === null) {
+    return <div className="aspect-video w-full bg-black/40 animate-pulse" />;
+  }
+
+  if (!accepted) {
+    return (
+      <div className="relative aspect-video w-full flex flex-col items-center justify-center gap-4 p-6 text-center"
+        style={{ background: "linear-gradient(135deg, #0f0a18 0%, #1a1028 100%)" }}>
+        <div className="absolute inset-0 opacity-[0.04]"
+          style={{ backgroundImage: "radial-gradient(circle at 50% 40%, rgba(145,71,255,0.6) 0%, transparent 60%)" }} />
+        <div className="relative flex flex-col items-center gap-4">
+          <div className="flex h-14 w-14 items-center justify-center rounded-full bg-purple-600/15 ring-1 ring-purple-500/30">
+            <FaTwitch className="h-7 w-7 text-purple-400" />
+          </div>
+          <div>
+            <p className="text-sm font-semibold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>
+              {t.twitchEmbed.title}
+            </p>
+            <p className="mt-1.5 text-xs leading-relaxed text-white/40 max-w-xs" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+              {t.twitchEmbed.description}
+            </p>
+          </div>
+          <button
+            onClick={accept}
+            className="rounded-lg bg-purple-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-purple-900/30 hover:bg-purple-500 transition-colors"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
+            {t.twitchEmbed.accept}
+          </button>
+          <a
+            href="/privacy#twitch"
+            className="text-[11px] text-white/20 hover:text-white/50 transition-colors underline underline-offset-2"
+            style={{ fontFamily: "'DM Sans', sans-serif" }}
+          >
+            {t.twitchEmbed.learnMore}
+          </a>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <iframe
+      src={embedUrl}
+      className="w-full h-full absolute inset-0"
+      allowFullScreen
+    />
+  );
+}

--- a/src/components/youtube-embed.tsx
+++ b/src/components/youtube-embed.tsx
@@ -1,0 +1,106 @@
+"use client";
+import { useState, useEffect } from "react";
+import { CirclePlay } from "lucide-react";
+import { useTranslations } from "@/lib/i18n/LanguageProvider";
+
+function getYoutubeConsent(): boolean {
+  try {
+    const prefs = localStorage.getItem("va-preferences");
+    if (!prefs) return false;
+    return !!JSON.parse(prefs).youtube;
+  } catch {
+    return false;
+  }
+}
+
+function saveYoutubeConsent() {
+  try {
+    const prefs = localStorage.getItem("va-preferences");
+    let p: Record<string, boolean> = {};
+    if (prefs) p = JSON.parse(prefs);
+    p.youtube = true;
+    localStorage.setItem("va-preferences", JSON.stringify(p));
+    if (!localStorage.getItem("cookie-consent")) {
+      localStorage.setItem("cookie-consent", "custom");
+    }
+    window.dispatchEvent(new Event("youtube-consent-changed"));
+  } catch {}
+}
+
+export default function YoutubeEmbed({ videoId }: { videoId: string }) {
+  const t = useTranslations();
+  const [accepted, setAccepted] = useState<boolean | null>(null);
+
+  useEffect(() => {
+    setAccepted(getYoutubeConsent());
+    const handler = () => setAccepted(getYoutubeConsent());
+    window.addEventListener("youtube-consent-changed", handler);
+    return () => window.removeEventListener("youtube-consent-changed", handler);
+  }, []);
+
+  const accept = () => {
+    saveYoutubeConsent();
+    setAccepted(true);
+  };
+
+  if (accepted === null) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-white/5">
+        <div className="aspect-video w-full bg-black/40 animate-pulse" />
+      </div>
+    );
+  }
+
+  if (!accepted) {
+    return (
+      <div className="overflow-hidden rounded-xl border border-white/8">
+        <div className="relative aspect-video w-full bg-gray-900 flex flex-col items-center justify-center gap-4 p-6 text-center"
+          style={{ background: "linear-gradient(135deg, #0f0f0f 0%, #1a1a1a 100%)" }}>
+          <div className="absolute inset-0 opacity-[0.03]"
+            style={{ backgroundImage: "radial-gradient(circle at 50% 40%, rgba(255,0,0,0.4) 0%, transparent 60%)" }} />
+          <div className="relative flex flex-col items-center gap-4">
+            <div className="flex h-14 w-14 items-center justify-center rounded-full bg-red-600/15 ring-1 ring-red-500/30">
+              <CirclePlay className="h-7 w-7 text-red-400" />
+            </div>
+            <div>
+              <p className="text-sm font-semibold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>
+                {t.youtubeEmbed.title}
+              </p>
+              <p className="mt-1.5 text-xs leading-relaxed text-white/40 max-w-xs" style={{ fontFamily: "'DM Sans', sans-serif" }}>
+                {t.youtubeEmbed.description}
+              </p>
+            </div>
+            <button
+              onClick={accept}
+              className="rounded-lg bg-red-600 px-5 py-2 text-sm font-semibold text-white shadow-lg shadow-red-900/30 hover:bg-red-500 transition-colors"
+              style={{ fontFamily: "'Syne', sans-serif" }}
+            >
+              {t.youtubeEmbed.accept}
+            </button>
+            <a
+              href="/privacy#youtube"
+              className="text-[11px] text-white/20 hover:text-white/50 transition-colors underline underline-offset-2"
+              style={{ fontFamily: "'DM Sans', sans-serif" }}
+            >
+              {t.youtubeEmbed.learnMore}
+            </a>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-xl border border-white/5">
+      <div className="relative aspect-video w-full bg-black">
+        <iframe
+          src={`https://www.youtube-nocookie.com/embed/${videoId}`}
+          className="absolute inset-0 h-full w-full"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+          allowFullScreen
+          title="YouTube video"
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/use-analytics.tsx
+++ b/src/hooks/use-analytics.tsx
@@ -3,10 +3,11 @@ import { useState, useEffect } from "react";
 
 type AnalyticsPreferences = {
   analytics: boolean;
+  youtube: boolean;
 };
 
 export function useAnalytics() {
-  const [preferences, setPreferences] = useState<AnalyticsPreferences>({ analytics: false });
+  const [preferences, setPreferences] = useState<AnalyticsPreferences>({ analytics: false, youtube: false });
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
@@ -42,7 +43,8 @@ export function useAnalytics() {
   const resetPreferences = () => {
     localStorage.removeItem("va-preferences");
     localStorage.removeItem("cookie-consent");
-    setPreferences({ analytics: false });
+    setPreferences({ analytics: false, youtube: false });
+    window.dispatchEvent(new Event("youtube-consent-changed"));
   };
 
   return {

--- a/src/hooks/use-analytics.tsx
+++ b/src/hooks/use-analytics.tsx
@@ -4,10 +4,11 @@ import { useState, useEffect } from "react";
 type AnalyticsPreferences = {
   analytics: boolean;
   youtube: boolean;
+  twitch: boolean;
 };
 
 export function useAnalytics() {
-  const [preferences, setPreferences] = useState<AnalyticsPreferences>({ analytics: false, youtube: false });
+  const [preferences, setPreferences] = useState<AnalyticsPreferences>({ analytics: false, youtube: false, twitch: false });
   const [isLoaded, setIsLoaded] = useState(false);
 
   useEffect(() => {
@@ -43,8 +44,9 @@ export function useAnalytics() {
   const resetPreferences = () => {
     localStorage.removeItem("va-preferences");
     localStorage.removeItem("cookie-consent");
-    setPreferences({ analytics: false, youtube: false });
+    setPreferences({ analytics: false, youtube: false, twitch: false });
     window.dispatchEvent(new Event("youtube-consent-changed"));
+    window.dispatchEvent(new Event("twitch-consent-changed"));
   };
 
   return {

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -372,6 +372,9 @@ export const translations = {
       analyticsLabel: "Analytics Cookies",
       analyticsDesc:
         "Help us understand how visitors interact with our website.",
+      youtubeLabel: "YouTube & Embedded Media",
+      youtubeDesc:
+        "Required to play embedded YouTube videos. Google/YouTube may set cookies and track your usage.",
       howWeUseTitle: "How we use cookies",
       howWeUseText:
         "OnThePixel.net uses cookies to enhance your experience, analyze site usage, and assist in our marketing efforts. We use Vercel Analytics to collect information about how visitors use our website. This data is anonymized and helps us improve our services.",
@@ -380,6 +383,13 @@ export const translations = {
       save: "Save Preferences",
       buttonLabel: "Cookie Settings",
       alwaysActive: "Always Active",
+    },
+    youtubeEmbed: {
+      title: "YouTube Video",
+      description:
+        "To play this video, YouTube cookies will be set. Google may track your usage across sites.",
+      accept: "Load video & accept cookies",
+      learnMore: "Learn more in our Privacy Policy",
     },
     playercount: {
       online: "Online players",
@@ -759,6 +769,9 @@ export const translations = {
       analyticsLabel: "Analyse-Cookies",
       analyticsDesc:
         "Helfen uns zu verstehen, wie Besucher mit unserer Website interagieren.",
+      youtubeLabel: "YouTube & Eingebettete Medien",
+      youtubeDesc:
+        "Erforderlich zum Abspielen eingebetteter YouTube-Videos. Google/YouTube kann dabei Cookies setzen und dein Nutzungsverhalten verfolgen.",
       howWeUseTitle: "Wie wir Cookies verwenden",
       howWeUseText:
         "OnThePixel.net verwendet Cookies, um dein Erlebnis zu verbessern, die Website-Nutzung zu analysieren und unsere Marketing-Aktivitäten zu unterstützen. Wir nutzen Vercel Analytics, um Informationen darüber zu erfassen, wie Besucher unsere Website nutzen. Diese Daten werden anonymisiert und helfen uns, unseren Service zu verbessern.",
@@ -767,6 +780,13 @@ export const translations = {
       save: "Einstellungen speichern",
       buttonLabel: "Cookie-Einstellungen",
       alwaysActive: "Immer aktiv",
+    },
+    youtubeEmbed: {
+      title: "YouTube-Video",
+      description:
+        "Zum Abspielen dieses Videos werden YouTube-Cookies gesetzt. Google kann dein Nutzungsverhalten seitenübergreifend verfolgen.",
+      accept: "Video laden & Cookies akzeptieren",
+      learnMore: "Mehr in unserer Datenschutzerklärung",
     },
     playercount: {
       online: "Spieler online",

--- a/src/lib/i18n/translations.ts
+++ b/src/lib/i18n/translations.ts
@@ -375,6 +375,9 @@ export const translations = {
       youtubeLabel: "YouTube & Embedded Media",
       youtubeDesc:
         "Required to play embedded YouTube videos. Google/YouTube may set cookies and track your usage.",
+      twitchLabel: "Twitch Live Streams",
+      twitchDesc:
+        "Required to display embedded Twitch streams on the Creators page. Twitch/Amazon may set cookies and track your usage.",
       howWeUseTitle: "How we use cookies",
       howWeUseText:
         "OnThePixel.net uses cookies to enhance your experience, analyze site usage, and assist in our marketing efforts. We use Vercel Analytics to collect information about how visitors use our website. This data is anonymized and helps us improve our services.",
@@ -389,6 +392,13 @@ export const translations = {
       description:
         "To play this video, YouTube cookies will be set. Google may track your usage across sites.",
       accept: "Load video & accept cookies",
+      learnMore: "Learn more in our Privacy Policy",
+    },
+    twitchEmbed: {
+      title: "Twitch Live Stream",
+      description:
+        "To show this stream, Twitch cookies will be set. Amazon/Twitch may track your usage across sites.",
+      accept: "Load stream & accept cookies",
       learnMore: "Learn more in our Privacy Policy",
     },
     playercount: {
@@ -772,6 +782,9 @@ export const translations = {
       youtubeLabel: "YouTube & Eingebettete Medien",
       youtubeDesc:
         "Erforderlich zum Abspielen eingebetteter YouTube-Videos. Google/YouTube kann dabei Cookies setzen und dein Nutzungsverhalten verfolgen.",
+      twitchLabel: "Twitch Live-Streams",
+      twitchDesc:
+        "Erforderlich zur Anzeige eingebetteter Twitch-Streams auf der Creators-Seite. Twitch/Amazon kann dabei Cookies setzen und dein Nutzungsverhalten verfolgen.",
       howWeUseTitle: "Wie wir Cookies verwenden",
       howWeUseText:
         "OnThePixel.net verwendet Cookies, um dein Erlebnis zu verbessern, die Website-Nutzung zu analysieren und unsere Marketing-Aktivitäten zu unterstützen. Wir nutzen Vercel Analytics, um Informationen darüber zu erfassen, wie Besucher unsere Website nutzen. Diese Daten werden anonymisiert und helfen uns, unseren Service zu verbessern.",
@@ -786,6 +799,13 @@ export const translations = {
       description:
         "Zum Abspielen dieses Videos werden YouTube-Cookies gesetzt. Google kann dein Nutzungsverhalten seitenübergreifend verfolgen.",
       accept: "Video laden & Cookies akzeptieren",
+      learnMore: "Mehr in unserer Datenschutzerklärung",
+    },
+    twitchEmbed: {
+      title: "Twitch Live-Stream",
+      description:
+        "Zur Anzeige dieses Streams werden Twitch-Cookies gesetzt. Amazon/Twitch kann dein Nutzungsverhalten seitenübergreifend verfolgen.",
+      accept: "Stream laden & Cookies akzeptieren",
       learnMore: "Mehr in unserer Datenschutzerklärung",
     },
     playercount: {


### PR DESCRIPTION
## Summary

- Replaces the plain textarea in the news dashboard with a **block-based editor**
- Content is stored as JSON in the existing `content` column — no schema changes needed
- Old plain-text articles load as a single paragraph block (full backward compat)

## Block types

| Block | Beschreibung |
|---|---|
| **Paragraph** | Fließtext mit `[Link](url)` Markdown-Support |
| **Heading** | H2 oder H3 Überschrift |
| **YouTube** | Video-Embed per URL (inkl. Live-Vorschau im Editor) |
| **Image** | Bild-URL + optionale Bildunterschrift |
| **Callout** | Farbige Info/Tipp/Warnung/Erfolg-Kachel |
| **Divider** | Horizontale Trennlinie |

## Editor features

- Blöcke per Klick hinzufügen (Dropdown-Menü)
- Reihenfolge per ↑/↓ Buttons ändern
- Einzelne Blöcke löschen
- YouTube-Vorschau direkt im Editor
- Block-Zähler + Wort-Zähler in der Toolbar

## Public page

Detailseite rendert jeden Block-Typ entsprechend. Legacy-Artikel (plain text) werden weiterhin korrekt angezeigt.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HDaxxXyQRpjxHVfiWhWJJc)_