### PR TITLE
Refactor NewsCard to remove fallback gradients and simplify image handling

### DIFF
--- a/src/app/news/[url]/page.tsx
+++ b/src/app/news/[url]/page.tsx
@@ -328,9 +328,9 @@ export default async function NewsPage({ params }: PageProps) {
           </Link>
 
           {/* Hero image */}
-          <div className="relative mb-8 w-full overflow-hidden rounded-2xl">
-            {item.image_url ? (
-              // eslint-disable-next-line @next/next/no-img-element
+          {item.image_url && (
+            <div className="relative mb-8 w-full overflow-hidden rounded-2xl">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
               <img
                 src={item.image_url}
                 alt={resolved.title}
@@ -341,32 +341,9 @@ export default async function NewsPage({ params }: PageProps) {
                 decoding="async"
                 className="h-56 w-full object-cover md:h-80"
               />
-            ) : (
-              <div
-                className="relative h-56 w-full overflow-hidden md:h-80"
-                style={{
-                  background: "linear-gradient(135deg, #0d2b1a 0%, #0a3d1f 50%, #052910 100%)",
-                }}
-              >
-                <div
-                  className="absolute inset-0 opacity-30"
-                  style={{
-                    backgroundImage: `radial-gradient(circle at 20% 50%, rgba(0,222,109,0.4) 0%, transparent 55%),
-                                      radial-gradient(circle at 80% 20%, rgba(0,222,109,0.15) 0%, transparent 40%)`,
-                  }}
-                />
-                <div className="absolute inset-0 flex items-center justify-center">
-                  <span
-                    className="select-none text-8xl font-black text-white/[0.04]"
-                    style={{ fontFamily: "'Syne', sans-serif" }}
-                  >
-                    OTP
-                  </span>
-                </div>
-              </div>
-            )}
-            <div className="absolute bottom-0 left-0 h-24 w-full bg-gradient-to-t from-gray-950 to-transparent" />
-          </div>
+              <div className="absolute bottom-0 left-0 h-24 w-full bg-gradient-to-t from-gray-950 to-transparent" />
+            </div>
+          )}
 
           {/* Title */}
           <h1

--- a/src/components/page/news.tsx
+++ b/src/components/page/news.tsx
@@ -39,24 +39,16 @@ function formatDate(dateStr: string, locale: Locale): string {
   }
 }
 
-const FALLBACK_GRADIENTS = [
-  "linear-gradient(135deg, #0d2b1a 0%, #0a3d1f 50%, #052910 100%)",
-  "linear-gradient(135deg, #0a1f2e 0%, #0d3347 50%, #041520 100%)",
-  "linear-gradient(135deg, #1a1a0d 0%, #2b2b0a 50%, #101005 100%)",
-];
 
 function NewsCard({
   item,
-  index,
   featured,
   locale,
 }: {
   item: NewsItem;
-  index: number;
   featured?: boolean;
   locale: Locale;
 }) {
-  const fallback = FALLBACK_GRADIENTS[index % FALLBACK_GRADIENTS.length];
   const tr = locale !== "en" ? item.translations?.[locale] : undefined;
   const title = tr?.title?.trim() ? tr.title : item.title;
   const description = tr?.short_description?.trim() ? tr.short_description : item.short_description;
@@ -68,9 +60,9 @@ function NewsCard({
         <div className="pointer-events-none absolute left-0 top-0 z-10 h-0.5 w-full origin-left scale-x-0 bg-gradient-to-r from-green-400 via-green-500 to-transparent transition-transform duration-300 group-hover:scale-x-100" />
 
         {/* Image area */}
-        <div className={`relative w-full shrink-0 overflow-hidden ${featured ? "h-52 md:h-64" : "h-40"}`}>
-          {item.image_url ? (
-            // eslint-disable-next-line @next/next/no-img-element
+        {item.image_url && (
+          <div className={`relative w-full shrink-0 overflow-hidden ${featured ? "h-52 md:h-64" : "h-40"}`}>
+            {/* eslint-disable-next-line @next/next/no-img-element */}
             <img
               src={item.image_url}
               alt={title}
@@ -81,43 +73,30 @@ function NewsCard({
               decoding="async"
               className="h-full w-full object-cover transition-transform duration-500 group-hover:scale-105"
             />
-          ) : (
-            <div
-              className="h-full w-full transition-transform duration-500 group-hover:scale-105"
-              style={{ background: fallback }}
-            >
-              <div
-                className="absolute inset-0 opacity-20"
-                style={{
-                  backgroundImage: `radial-gradient(circle at 20% 50%, rgba(0,222,109,0.3) 0%, transparent 50%),
-                                    radial-gradient(circle at 80% 20%, rgba(0,222,109,0.15) 0%, transparent 40%)`,
-                }}
-              />
-              <div className="absolute inset-0 flex items-center justify-center">
-                <span
-                  className="select-none text-5xl font-black text-white/5"
-                  style={{ fontFamily: "'Syne', sans-serif" }}
-                >
-                  OTP
-                </span>
-              </div>
+
+            <div className="absolute bottom-0 left-0 h-16 w-full bg-gradient-to-t from-gray-950/80 to-transparent" />
+
+            <div className="absolute bottom-3 left-4">
+              <span
+                className="rounded-md bg-black/50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-green-400 backdrop-blur-sm"
+                style={{ fontFamily: "'Syne', sans-serif" }}
+              >
+                {formatDate(item.published_at, locale)}
+              </span>
             </div>
-          )}
+          </div>
+        )}
 
-          <div className="absolute bottom-0 left-0 h-16 w-full bg-gradient-to-t from-gray-950/80 to-transparent" />
-
-          <div className="absolute bottom-3 left-4">
+        {/* Content */}
+        <div className="flex flex-1 flex-col gap-2 p-5">
+          {!item.image_url && (
             <span
-              className="rounded-md bg-black/50 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-green-400 backdrop-blur-sm"
+              className="w-fit rounded-md bg-white/5 px-2.5 py-1 text-[10px] font-bold uppercase tracking-widest text-green-400"
               style={{ fontFamily: "'Syne', sans-serif" }}
             >
               {formatDate(item.published_at, locale)}
             </span>
-          </div>
-        </div>
-
-        {/* Content */}
-        <div className="flex flex-1 flex-col gap-2 p-5">
+          )}
           <div className="flex items-start justify-between gap-3">
             <h3
               className={`font-bold leading-snug text-white transition-colors duration-200 group-hover:text-green-400 group-hover:[text-shadow:0_0_20px_rgba(0,222,109,0.2)] ${
@@ -215,7 +194,7 @@ export default async function News() {
             <div className="flex flex-col gap-4">
               {featured && (
                 <Reveal direction="up" distance={50} duration={0.9}>
-                  <NewsCard item={featured} index={0} featured locale={locale} />
+                  <NewsCard item={featured} featured locale={locale} />
                 </Reveal>
               )}
               {rest.length > 0 && (
@@ -230,7 +209,6 @@ export default async function News() {
                     <NewsCard
                       key={item.id}
                       item={item}
-                      index={i + 1}
                       locale={locale}
                     />
                   ))}


### PR DESCRIPTION
## Summary
This PR refactors the NewsCard component to remove the index-based fallback gradient system and simplifies the image rendering logic. The component now only displays images when they are available, eliminating the need for placeholder gradients.

## Key Changes
- **Removed fallback gradient system**: Deleted the `FALLBACK_GRADIENTS` array and removed the `index` prop from NewsCard, as it was only used to select a fallback gradient
- **Simplified image rendering**: Changed from a conditional ternary operator to a simpler conditional render that only displays the image container when `item.image_url` exists
- **Removed placeholder UI**: Eliminated the fallback gradient div with the "OTP" text that was displayed when no image was available
- **Improved date display logic**: When no image is present, the date badge now appears in the content area with adjusted styling (`bg-white/5` instead of `bg-black/50`)
- **Cleaned up component props**: Removed the `index` parameter from all NewsCard invocations throughout the component

## Implementation Details
- The date badge styling is now context-aware: it uses `bg-black/50` when displayed over an image, and `bg-white/5` when displayed in the content area without an image
- The image container and its gradient overlay are now only rendered when an image URL is present, reducing DOM complexity for cards without images
- All references to the `index` prop have been removed from the parent component's NewsCard calls

https://claude.ai/code/session_01E5SgeAYMuAoTMur9psTRtW