### PR TITLE
chore: update dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
         "prettier": "^3.9.4",
         "prettier-plugin-tailwindcss": "^0.8.0",
         "tailwindcss": "^4.3.2",
-        "tsx": "^4.22.4",
+        "tsx": "^4.22.5",
         "typescript": "^6.0.3"
       }
     },
@@ -12737,9 +12737,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.22.4",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.4.tgz",
-      "integrity": "sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==",
+      "version": "4.22.5",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.22.5.tgz",
+      "integrity": "sha512-F7JnSfPl5ASt6LqwWyUQ3T8BwN3q0eQEbFMYa2iRWaVQmmudo0d7fRmwM4O002gsvW1bs0yBYioutsAjqLJMvQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "prettier": "^3.9.4",
     "prettier-plugin-tailwindcss": "^0.8.0",
     "tailwindcss": "^4.3.2",
-    "tsx": "^4.22.4",
+    "tsx": "^4.22.5",
     "typescript": "^6.0.3"
   },
   "overrides": {


### PR DESCRIPTION
## Summary
- `tsx` `^4.22.4` → `^4.22.5` (patch)
- `package-lock.json` regenerated to match

`next-auth` remains on `5.0.0-beta.31` (intentional — the npm `latest` dist-tag still points to the older stable `4.x` line, so that's not an actual update). No other direct dependencies had updates available within their existing semver ranges.

## Test plan
- [x] `npm install` completes cleanly
- [x] `npm audit` — 0 vulnerabilities
- [x] `npm run build` — production build succeeds
- [x] `npm run typecheck` — no new errors (pre-existing `tsconfig.json` `baseUrl` deprecation warning is unrelated to this change)

---
_Generated by [Claude Code](https://claude.ai/code/session_016Q1sp5Mp6XXyhiocbfqYpr)_