### PR TITLE
feat(dashboard): Team-Verwaltung (PocketID)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,3 +5,8 @@ AUTH_SECRET=YOUR_AUTH_SECRET_HERE
 # Discord OAuth
 AUTH_DISCORD_ID=YOUR_DISCORD_CLIENT_ID
 AUTH_DISCORD_SECRET=YOUR_DISCORD_CLIENT_SECRET
+
+# PocketID (Team management) — API key sent as the X-API-KEY header
+pocketid-apikey=YOUR_POCKETID_API_KEY
+# Optional override of the PocketID base URL (defaults to https://auth.onthepixel.net)
+# POCKETID_API_URL=https://auth.onthepixel.net

--- a/src/app/api/dashboard/team/[id]/route.ts
+++ b/src/app/api/dashboard/team/[id]/route.ts
@@ -1,0 +1,33 @@
+import { NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { pocketIdFetch, PocketIdError } from "@/lib/pocketid";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+/** DELETE — remove a team member from PocketID. */
+export async function DELETE(
+  _req: Request,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  if (!id)
+    return NextResponse.json({ error: "Missing user id" }, { status: 400 });
+
+  try {
+    await pocketIdFetch(`/api/users/${id}`, { method: "DELETE" });
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    if (e instanceof PocketIdError)
+      return NextResponse.json(
+        { error: e.message, detail: e.body },
+        { status: e.status >= 400 ? e.status : 500 },
+      );
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -1,0 +1,146 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  pocketIdFetch,
+  fetchAllPages,
+  otpGroupIds,
+  isOtpMember,
+  getClaim,
+  PocketIdError,
+  type PocketUser,
+  type UserGroup,
+} from "@/lib/pocketid";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+function handleError(e: unknown) {
+  if (e instanceof PocketIdError) {
+    return NextResponse.json(
+      { error: e.message, detail: e.body },
+      { status: e.status >= 400 ? e.status : 500 },
+    );
+  }
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error("[team route]", e);
+  return NextResponse.json({ error: msg }, { status: 500 });
+}
+
+/** GET — list OTP team members and the available OTP groups. */
+export async function GET() {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const [groups, users] = await Promise.all([
+      fetchAllPages<UserGroup>("/api/user-groups"),
+      fetchAllPages<PocketUser>("/api/users"),
+    ]);
+
+    const otpIds = otpGroupIds(groups);
+    const otpGroups = groups
+      .filter((g) => otpIds.has(g.id))
+      .map((g) => ({ id: g.id, name: g.name, friendlyName: g.friendlyName }));
+
+    const members = users
+      .filter((u) => isOtpMember(u, otpIds))
+      .map((u) => ({
+        id: u.id,
+        username: u.username,
+        displayName: u.displayName ?? u.username,
+        email: u.email ?? "",
+        disabled: !!u.disabled,
+        discordId: getClaim(u, "Discord-id"),
+        minecraftUuid: getClaim(u, "Minecraft-uuid"),
+        groups: (u.userGroups ?? [])
+          .filter((g) => otpIds.has(g.id))
+          .map((g) => ({ id: g.id, friendlyName: g.friendlyName ?? g.name })),
+      }));
+
+    return NextResponse.json({ users: members, groups: otpGroups });
+  } catch (e) {
+    return handleError(e);
+  }
+}
+
+/** POST — create a new team member via /api/signup, then set custom claims. */
+export async function POST(req: NextRequest) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const body = await req.json();
+    const username = String(body.username ?? "").trim();
+    const groupId = String(body.groupId ?? "").trim();
+    const discordId = String(body.discordId ?? "").trim();
+    const minecraftUuid = String(body.minecraftUuid ?? "").trim();
+    const email =
+      String(body.email ?? "").trim() ||
+      `${username.toLowerCase()}@onthepixel.net`;
+
+    if (!username)
+      return NextResponse.json(
+        { error: "Username ist erforderlich." },
+        { status: 400 },
+      );
+    if (!groupId)
+      return NextResponse.json(
+        { error: "Eine Gruppe muss ausgewählt werden." },
+        { status: 400 },
+      );
+
+    // Ensure the chosen group is actually an OTP-team group.
+    const groups = await fetchAllPages<UserGroup>("/api/user-groups");
+    const otpIds = otpGroupIds(groups);
+    if (!otpIds.has(groupId))
+      return NextResponse.json(
+        { error: "Ungültige Gruppe (keine OTP-Gruppe)." },
+        { status: 400 },
+      );
+
+    // 1) Create the user account.
+    const signupRes = await pocketIdFetch("/api/signup", {
+      method: "POST",
+      body: JSON.stringify({
+        username,
+        email,
+        emailVerified: true,
+        displayName: username,
+        userGroupIds: [groupId],
+        disabled: false,
+        isAdmin: false,
+      }),
+    });
+    const created = (await signupRes.json()) as PocketUser;
+
+    // 2) Set the Discord / Minecraft custom claims on the new user.
+    const claims = [
+      { key: "Discord-id", value: discordId },
+      { key: "Minecraft-uuid", value: minecraftUuid },
+    ].filter((c) => c.value);
+
+    let claimsWarning: string | undefined;
+    if (created?.id && claims.length > 0) {
+      try {
+        await pocketIdFetch(`/api/custom-claims/user/${created.id}`, {
+          method: "PUT",
+          body: JSON.stringify(claims),
+        });
+      } catch (e) {
+        claimsWarning =
+          e instanceof PocketIdError
+            ? `Nutzer angelegt, aber Custom Claims fehlgeschlagen: ${e.body || e.message}`
+            : `Nutzer angelegt, aber Custom Claims fehlgeschlagen: ${String(e)}`;
+      }
+    }
+
+    return NextResponse.json(
+      { data: created, warning: claimsWarning },
+      { status: 201 },
+    );
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -9,6 +9,7 @@ import {
   LayoutDashboard,
   Newspaper,
   Users,
+  UserCog,
   LogOut,
   Menu,
   X,
@@ -20,6 +21,7 @@ const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true },
   { href: "/dashboard/news", label: "News", icon: Newspaper },
   { href: "/dashboard/creators", label: "Creators", icon: Users },
+  { href: "/dashboard/team", label: "Team", icon: UserCog },
 ];
 
 function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -37,7 +39,7 @@ function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
       <aside
         className={cn(
           "fixed inset-y-0 left-0 z-30 flex w-64 flex-col border-r border-white/5 bg-gray-950 transition-transform duration-300 lg:translate-x-0",
-          open ? "translate-x-0" : "-translate-x-full"
+          open ? "translate-x-0" : "-translate-x-full",
         )}
       >
         <div className="flex h-16 items-center justify-between border-b border-white/5 px-5">
@@ -71,7 +73,7 @@ function Sidebar({ open, onClose }: { open: boolean; onClose: () => void }) {
                   "flex items-center gap-3 rounded-lg px-3 py-2.5 text-sm font-medium transition-all duration-150",
                   active
                     ? "bg-green-500/10 text-green-400"
-                    : "text-white/50 hover:bg-white/5 hover:text-white"
+                    : "text-white/50 hover:bg-white/5 hover:text-white",
                 )}
               >
                 <item.icon size={18} />
@@ -145,7 +147,10 @@ export default function DashboardLayout({
             </button>
             <div className="flex items-center gap-2 text-white/20 lg:hidden">
               <Shield size={14} className="text-green-400/60" />
-              <span className="text-xs font-semibold" style={{ fontFamily: "'Syne', sans-serif" }}>
+              <span
+                className="text-xs font-semibold"
+                style={{ fontFamily: "'Syne', sans-serif" }}
+              >
                 OTP <span className="text-green-400">Admin</span>
               </span>
             </div>

--- a/src/app/dashboard/overview.tsx
+++ b/src/app/dashboard/overview.tsx
@@ -2,12 +2,19 @@
 
 import React, { useEffect, useState } from "react";
 import Link from "next/link";
-import { Newspaper, Users, ArrowRight, TrendingUp } from "lucide-react";
+import {
+  Newspaper,
+  Users,
+  UserCog,
+  ArrowRight,
+  TrendingUp,
+} from "lucide-react";
 import AuthGuard from "./auth-guard";
 
 interface StatsState {
   newsCount: number | null;
   creatorsCount: number | null;
+  teamCount: number | null;
   loading: boolean;
 }
 
@@ -45,7 +52,11 @@ function StatCard({
         </div>
       </div>
       <div className="mt-4 flex items-center gap-1 text-xs text-white/30 transition-colors group-hover:text-white/60">
-        Manage <ArrowRight size={12} className="transition-transform group-hover:translate-x-0.5" />
+        Manage{" "}
+        <ArrowRight
+          size={12}
+          className="transition-transform group-hover:translate-x-0.5"
+        />
       </div>
     </Link>
   );
@@ -55,27 +66,42 @@ function OverviewContent() {
   const [stats, setStats] = useState<StatsState>({
     newsCount: null,
     creatorsCount: null,
+    teamCount: null,
     loading: true,
   });
 
   useEffect(() => {
     async function load() {
       try {
-        const [newsRes, creatorsRes] = await Promise.all([
-          fetch("https://cms.onthepixel.net/items/News?limit=1&meta=total_count"),
-          fetch("https://cms.onthepixel.net/items/Creators?limit=1&meta=total_count"),
+        const [newsRes, creatorsRes, teamRes] = await Promise.all([
+          fetch(
+            "https://cms.onthepixel.net/items/News?limit=1&meta=total_count",
+          ),
+          fetch(
+            "https://cms.onthepixel.net/items/Creators?limit=1&meta=total_count",
+          ),
+          fetch("/api/dashboard/team"),
         ]);
-        const [newsData, creatorsData] = await Promise.all([
+        const [newsData, creatorsData, teamData] = await Promise.all([
           newsRes.json(),
           creatorsRes.json(),
+          teamRes.ok ? teamRes.json() : Promise.resolve({ users: [] }),
         ]);
         setStats({
           newsCount: newsData?.meta?.total_count ?? newsData?.data?.length ?? 0,
-          creatorsCount: creatorsData?.meta?.total_count ?? creatorsData?.data?.length ?? 0,
+          creatorsCount:
+            creatorsData?.meta?.total_count ?? creatorsData?.data?.length ?? 0,
+          teamCount: teamData?.users?.length ?? 0,
           loading: false,
         });
       } catch {
-        setStats((s) => ({ ...s, loading: false, newsCount: 0, creatorsCount: 0 }));
+        setStats((s) => ({
+          ...s,
+          loading: false,
+          newsCount: 0,
+          creatorsCount: 0,
+          teamCount: 0,
+        }));
       }
     }
     load();
@@ -110,6 +136,13 @@ function OverviewContent() {
           href="/dashboard/creators"
           color="bg-blue-500/20"
         />
+        <StatCard
+          label="Team Members"
+          value={stats.teamCount}
+          icon={UserCog}
+          href="/dashboard/team"
+          color="bg-orange-500/20"
+        />
         <div className="rounded-xl border border-white/5 bg-white/[0.03] p-6">
           <div className="flex items-start justify-between">
             <div>
@@ -131,6 +164,12 @@ function OverviewContent() {
               className="flex items-center gap-2 rounded-lg bg-blue-500/10 px-3 py-2 text-sm font-medium text-blue-400 transition-colors hover:bg-blue-500/20"
             >
               <Users size={14} /> Manage Creators
+            </Link>
+            <Link
+              href="/dashboard/team"
+              className="flex items-center gap-2 rounded-lg bg-orange-500/10 px-3 py-2 text-sm font-medium text-orange-400 transition-colors hover:bg-orange-500/20"
+            >
+              <UserCog size={14} /> Manage Team
             </Link>
           </div>
         </div>

--- a/src/app/dashboard/team/page.tsx
+++ b/src/app/dashboard/team/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import type { Metadata } from "next";
+import TeamDashboard from "./team-dashboard";
+
+export const metadata: Metadata = {
+  title: "Team Management – Admin Dashboard",
+  robots: { index: false },
+};
+
+export default function DashboardTeamPage() {
+  return <TeamDashboard />;
+}

--- a/src/app/dashboard/team/team-dashboard.tsx
+++ b/src/app/dashboard/team/team-dashboard.tsx
@@ -1,0 +1,577 @@
+"use client";
+
+import React, { useEffect, useState, useCallback } from "react";
+import {
+  Users,
+  Search,
+  RefreshCw,
+  Plus,
+  Trash2,
+  X,
+  Loader2,
+  AlertCircle,
+  UserPlus,
+  Shield,
+  Save,
+} from "lucide-react";
+import { FaDiscord } from "react-icons/fa";
+import AuthGuard from "../auth-guard";
+
+interface Group {
+  id: string;
+  friendlyName: string;
+  name?: string;
+}
+
+interface Member {
+  id: string;
+  username: string;
+  displayName: string;
+  email: string;
+  disabled: boolean;
+  discordId: string;
+  minecraftUuid: string;
+  groups: { id: string; friendlyName: string }[];
+}
+
+function avatarUrl(nameOrUuid: string) {
+  const id = nameOrUuid?.trim() || "MHF_Steve";
+  return `https://api.mcskin.me/avatar/${encodeURIComponent(id)}?size=128`;
+}
+
+function Field({
+  label,
+  children,
+}: {
+  label: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-white/40">{label}</label>
+      {children}
+    </div>
+  );
+}
+
+/* --- Create member modal --- */
+function CreateModal({
+  groups,
+  onClose,
+  onCreated,
+}: {
+  groups: Group[];
+  onClose: () => void;
+  onCreated: (msg: string) => void;
+}) {
+  const [username, setUsername] = useState("");
+  const [emailTouched, setEmailTouched] = useState(false);
+  const [email, setEmail] = useState("");
+  const [minecraftUuid, setMinecraftUuid] = useState("");
+  const [discordId, setDiscordId] = useState("");
+  const [groupId, setGroupId] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const effectiveEmail = emailTouched
+    ? email
+    : username
+      ? `${username.toLowerCase()}@onthepixel.net`
+      : "";
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!username.trim()) return setError("Username ist erforderlich.");
+    if (!groupId) return setError("Bitte eine Gruppe auswählen.");
+    setLoading(true);
+    try {
+      const res = await fetch("/api/dashboard/team", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          username: username.trim(),
+          email: effectiveEmail.trim(),
+          minecraftUuid: minecraftUuid.trim(),
+          discordId: discordId.trim(),
+          groupId,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        throw new Error(
+          data.detail || data.error || "Erstellen fehlgeschlagen.",
+        );
+      }
+      onCreated(data.warning ?? `${username} wurde angelegt.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-lg rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-green-500/15">
+            <UserPlus size={18} className="text-green-400" />
+          </div>
+          <div>
+            <p className="font-semibold text-white">Neues Team-Mitglied</p>
+            <p className="text-xs text-white/40">
+              Legt ein neues Konto in PocketID an.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="ml-auto rounded-md p-1 text-white/30 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <Field label="Username *">
+            <input
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+              placeholder="z. B. Notch"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
+              autoFocus
+            />
+          </Field>
+
+          <Field label="E-Mail (wird verifiziert angelegt)">
+            <input
+              type="email"
+              value={effectiveEmail}
+              onChange={(e) => {
+                setEmailTouched(true);
+                setEmail(e.target.value);
+              }}
+              placeholder="username@onthepixel.net"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
+            />
+          </Field>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Minecraft-UUID">
+              <input
+                value={minecraftUuid}
+                onChange={(e) => setMinecraftUuid(e.target.value)}
+                placeholder="b35d0c41-37e8-…"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
+              />
+            </Field>
+            <Field label="Discord-ID">
+              <input
+                value={discordId}
+                onChange={(e) => setDiscordId(e.target.value)}
+                placeholder="1279066016005099536"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
+              />
+            </Field>
+          </div>
+
+          <Field label="Gruppe *">
+            <select
+              value={groupId}
+              onChange={(e) => setGroupId(e.target.value)}
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white transition-all outline-none focus:border-green-500/40 focus:ring-1 focus:ring-green-500/20"
+            >
+              <option value="" className="bg-gray-900">
+                Gruppe auswählen…
+              </option>
+              {groups.map((g) => (
+                <option key={g.id} value={g.id} className="bg-gray-900">
+                  {g.friendlyName}
+                </option>
+              ))}
+            </select>
+          </Field>
+
+          {error && (
+            <div className="flex items-start gap-2.5 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
+              <AlertCircle size={15} className="mt-0.5 shrink-0" />
+              <span className="break-words">{error}</span>
+            </div>
+          )}
+
+          <div className="mt-1 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 transition-colors hover:bg-white/5"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-green-500 py-2 text-sm font-semibold text-black transition-colors hover:bg-green-400 disabled:opacity-60"
+            >
+              {loading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <UserPlus size={14} />
+              )}
+              Erstellen
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/* --- Delete modal --- */
+function DeleteModal({
+  member,
+  onConfirm,
+  onCancel,
+  loading,
+}: {
+  member: Member;
+  onConfirm: () => void;
+  onCancel: () => void;
+  loading: boolean;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onCancel}
+      />
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <div className="mb-4 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-red-500/15">
+            <Trash2 size={18} className="text-red-400" />
+          </div>
+          <div>
+            <p className="font-semibold text-white">Mitglied löschen</p>
+            <p className="text-xs text-white/40">
+              Das kann nicht rückgängig gemacht werden.
+            </p>
+          </div>
+        </div>
+        <p className="mb-6 rounded-lg bg-white/5 px-3 py-2 text-sm text-white/70">
+          &quot;{member.username}&quot;
+        </p>
+        <div className="flex gap-3">
+          <button
+            onClick={onCancel}
+            className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 transition-colors hover:bg-white/5"
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={onConfirm}
+            disabled={loading}
+            className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-red-500 py-2 text-sm font-semibold text-white transition-colors hover:bg-red-600 disabled:opacity-60"
+          >
+            {loading ? (
+              <Loader2 size={14} className="animate-spin" />
+            ) : (
+              <Trash2 size={14} />
+            )}{" "}
+            Löschen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* --- Table row --- */
+function MemberRow({
+  member,
+  onDelete,
+}: {
+  member: Member;
+  onDelete: (m: Member) => void;
+}) {
+  return (
+    <tr className="border-b border-white/5 transition-colors hover:bg-white/[0.02]">
+      <td className="py-3 pr-3 pl-4">
+        <div className="flex items-center gap-3">
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img
+            src={avatarUrl(member.minecraftUuid || member.username)}
+            alt={member.username}
+            width={40}
+            height={40}
+            className="h-10 w-10 shrink-0 rounded-lg bg-white/5"
+          />
+          <div className="min-w-0">
+            <p className="truncate text-sm font-medium text-white">
+              {member.username}
+              {member.disabled && (
+                <span className="ml-2 rounded bg-red-500/15 px-1.5 py-0.5 text-[10px] font-medium text-red-400">
+                  deaktiviert
+                </span>
+              )}
+            </p>
+            <p className="truncate text-xs text-white/30">{member.email}</p>
+          </div>
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        <div className="flex flex-wrap gap-1.5">
+          {member.groups.length > 0 ? (
+            member.groups.map((g) => (
+              <span
+                key={g.id}
+                className="inline-flex items-center gap-1 rounded-md bg-green-500/10 px-2 py-1 text-xs font-medium text-green-400"
+              >
+                <Shield size={11} /> {g.friendlyName}
+              </span>
+            ))
+          ) : (
+            <span className="text-xs text-white/20">—</span>
+          )}
+        </div>
+      </td>
+      <td className="px-3 py-3">
+        {member.discordId ? (
+          <span className="inline-flex items-center gap-1.5 text-xs text-white/50">
+            <FaDiscord size={13} className="text-indigo-400" />{" "}
+            {member.discordId}
+          </span>
+        ) : (
+          <span className="text-xs text-white/15">—</span>
+        )}
+      </td>
+      <td className="px-3 py-3">
+        {member.minecraftUuid ? (
+          <span className="font-mono text-xs text-white/40">
+            {member.minecraftUuid}
+          </span>
+        ) : (
+          <span className="text-xs text-white/15">—</span>
+        )}
+      </td>
+      <td className="py-3 pr-4 pl-3">
+        <button
+          onClick={() => onDelete(member)}
+          className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 transition-colors hover:bg-red-500/10 hover:text-red-400"
+        >
+          <Trash2 size={12} />
+        </button>
+      </td>
+    </tr>
+  );
+}
+
+/* --- Main --- */
+function TeamDashboardContent() {
+  const [members, setMembers] = useState<Member[]>([]);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [search, setSearch] = useState("");
+  const [showCreate, setShowCreate] = useState(false);
+  const [deleteTarget, setDeleteTarget] = useState<Member | null>(null);
+  const [deleteLoading, setDeleteLoading] = useState(false);
+  const [toast, setToast] = useState<string | null>(null);
+
+  const showToast = (msg: string) => {
+    setToast(msg);
+    setTimeout(() => setToast(null), 4000);
+  };
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setLoadError(null);
+    try {
+      const res = await fetch("/api/dashboard/team");
+      const data = await res.json();
+      if (!res.ok)
+        throw new Error(data.detail || data.error || "Laden fehlgeschlagen.");
+      setMembers(data.users ?? []);
+      setGroups(data.groups ?? []);
+    } catch (e) {
+      setMembers([]);
+      setGroups([]);
+      setLoadError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const handleDelete = async () => {
+    if (!deleteTarget) return;
+    setDeleteLoading(true);
+    try {
+      const res = await fetch(`/api/dashboard/team/${deleteTarget.id}`, {
+        method: "DELETE",
+      });
+      if (!res.ok) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.detail || data.error || "Löschen fehlgeschlagen.");
+      }
+      await load();
+      showToast(`${deleteTarget.username} wurde gelöscht.`);
+    } catch (e) {
+      showToast(e instanceof Error ? e.message : String(e));
+    } finally {
+      setDeleteLoading(false);
+      setDeleteTarget(null);
+    }
+  };
+
+  const filtered = members.filter((m) => {
+    const q = search.toLowerCase();
+    return (
+      m.username.toLowerCase().includes(q) ||
+      m.email.toLowerCase().includes(q) ||
+      m.discordId.toLowerCase().includes(q) ||
+      m.minecraftUuid.toLowerCase().includes(q)
+    );
+  });
+
+  return (
+    <div>
+      {toast && (
+        <div className="fixed right-6 bottom-6 z-50 flex items-center gap-2 rounded-xl border border-green-500/20 bg-gray-900 px-4 py-3 text-sm font-medium text-green-400 shadow-2xl">
+          <Save size={14} /> {toast}
+        </div>
+      )}
+      {showCreate && (
+        <CreateModal
+          groups={groups}
+          onClose={() => setShowCreate(false)}
+          onCreated={(msg) => {
+            setShowCreate(false);
+            load();
+            showToast(msg);
+          }}
+        />
+      )}
+      {deleteTarget && (
+        <DeleteModal
+          member={deleteTarget}
+          onConfirm={handleDelete}
+          onCancel={() => setDeleteTarget(null)}
+          loading={deleteLoading}
+        />
+      )}
+
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1
+            className="text-2xl font-bold text-white"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
+            Team
+          </h1>
+          <p className="mt-0.5 text-sm text-white/40">
+            {members.length} Mitglieder
+          </p>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <div className="relative">
+            <Search
+              size={15}
+              className="absolute top-1/2 left-3 -translate-y-1/2 text-white/30"
+            />
+            <input
+              type="text"
+              placeholder="Suchen…"
+              value={search}
+              onChange={(e) => setSearch(e.target.value)}
+              className="h-9 w-full rounded-lg border border-white/10 bg-white/5 pr-4 pl-9 text-sm text-white placeholder-white/30 outline-none focus:border-green-500/40 sm:w-56"
+            />
+          </div>
+          <button
+            onClick={load}
+            disabled={loading}
+            className="flex h-9 items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-50"
+          >
+            <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          </button>
+          <button
+            onClick={() => setShowCreate(true)}
+            className="flex h-9 items-center gap-2 rounded-lg bg-green-500 px-4 text-sm font-semibold text-black transition-colors hover:bg-green-400"
+          >
+            <Plus size={15} /> Neues Mitglied
+          </button>
+        </div>
+      </div>
+
+      {loadError && (
+        <div className="mb-4 flex items-start gap-2.5 rounded-xl border border-red-500/20 bg-red-500/10 p-4 text-sm text-red-300">
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span className="break-words">{loadError}</span>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-xl border border-white/5 bg-white/[0.02]">
+        {loading ? (
+          <div className="flex items-center justify-center py-16">
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+          </div>
+        ) : filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center gap-3 py-16">
+            <Users size={32} className="text-white/10" />
+            <p className="text-sm text-white/30">
+              Keine Team-Mitglieder gefunden.
+            </p>
+            <button
+              onClick={() => setShowCreate(true)}
+              className="flex items-center gap-2 rounded-lg bg-green-500/10 px-4 py-2 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/20"
+            >
+              <Plus size={14} /> Erstes Mitglied anlegen
+            </button>
+          </div>
+        ) : (
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[820px]">
+              <thead>
+                <tr className="border-b border-white/5">
+                  <th className="py-3 pr-3 pl-4 text-left text-xs font-medium tracking-wider text-white/30 uppercase">
+                    Mitglied
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium tracking-wider text-white/30 uppercase">
+                    Gruppen
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium tracking-wider text-white/30 uppercase">
+                    Discord-ID
+                  </th>
+                  <th className="px-3 py-3 text-left text-xs font-medium tracking-wider text-white/30 uppercase">
+                    Minecraft-UUID
+                  </th>
+                  <th className="py-3 pr-4 pl-3 text-left text-xs font-medium tracking-wider text-white/30 uppercase">
+                    Aktionen
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {filtered.map((m) => (
+                  <MemberRow key={m.id} member={m} onDelete={setDeleteTarget} />
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function TeamDashboard() {
+  return (
+    <AuthGuard>
+      <TeamDashboardContent />
+    </AuthGuard>
+  );
+}

--- a/src/lib/pocketid.ts
+++ b/src/lib/pocketid.ts
@@ -1,0 +1,154 @@
+/**
+ * Server-side helper for the PocketID admin API (https://auth.onthepixel.net).
+ *
+ * All requests must send an `X-API-KEY` header. The key is read from the
+ * `pocketid-apikey` system/environment variable (with a `POCKETID_APIKEY`
+ * fallback for environments that disallow dashes in variable names).
+ *
+ * This module is server-only — the API key must never reach the browser.
+ */
+
+export const POCKETID_BASE =
+  process.env.POCKETID_API_URL ?? "https://auth.onthepixel.net";
+
+/** The custom claim key/value that marks a group as belonging to the OTP team. */
+const TEAM_CLAIM_KEY = "Team";
+const TEAM_CLAIM_VALUE = "OTP";
+
+export interface CustomClaim {
+  key: string;
+  value: string;
+}
+
+export interface UserGroup {
+  id: string;
+  friendlyName: string;
+  name: string;
+  customClaims?: CustomClaim[];
+  userCount?: number;
+  createdAt?: string;
+}
+
+export interface PocketUser {
+  id: string;
+  username: string;
+  email?: string | null;
+  emailVerified?: boolean;
+  displayName?: string;
+  isAdmin?: boolean;
+  customClaims?: CustomClaim[];
+  userGroups?: UserGroup[];
+  disabled?: boolean;
+}
+
+interface Paginated<T> {
+  data: T[];
+  pagination?: {
+    totalPages?: number;
+    totalItems?: number;
+    currentPage?: number;
+    itemsPerPage?: number;
+  };
+}
+
+export function getApiKey(): string {
+  return process.env["pocketid-apikey"] ?? process.env.POCKETID_APIKEY ?? "";
+}
+
+/**
+ * Thrown when an upstream PocketID request fails. Carries the upstream status
+ * code and response body so the calling route can forward them to the client.
+ */
+export class PocketIdError extends Error {
+  status: number;
+  body: string;
+  constructor(message: string, status: number, body: string) {
+    super(message);
+    this.name = "PocketIdError";
+    this.status = status;
+    this.body = body;
+  }
+}
+
+export async function pocketIdFetch(
+  path: string,
+  init: RequestInit = {},
+): Promise<Response> {
+  const apiKey = getApiKey();
+  if (!apiKey) {
+    throw new PocketIdError(
+      "PocketID API key is not configured (set the `pocketid-apikey` environment variable).",
+      500,
+      "",
+    );
+  }
+
+  const headers = new Headers(init.headers);
+  headers.set("X-API-KEY", apiKey);
+  headers.set("Accept", "application/json");
+  if (init.body && !headers.has("Content-Type")) {
+    headers.set("Content-Type", "application/json");
+  }
+
+  const res = await fetch(`${POCKETID_BASE}${path}`, {
+    ...init,
+    headers,
+    cache: "no-store",
+  });
+
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new PocketIdError(
+      `PocketID request failed: ${res.status} ${res.statusText}`,
+      res.status,
+      body,
+    );
+  }
+
+  return res;
+}
+
+/** Fetch every page of a paginated PocketID collection endpoint. */
+export async function fetchAllPages<T>(path: string): Promise<T[]> {
+  const items: T[] = [];
+  let page = 1;
+  let totalPages = 1;
+  const sep = path.includes("?") ? "&" : "?";
+
+  do {
+    const res = await pocketIdFetch(
+      `${path}${sep}pagination[page]=${page}&pagination[limit]=100`,
+    );
+    const json = (await res.json()) as Paginated<T>;
+    items.push(...(json.data ?? []));
+    totalPages = json.pagination?.totalPages ?? 1;
+    page += 1;
+  } while (page <= totalPages);
+
+  return items;
+}
+
+/** True when a group carries the `Team=OTP` custom claim. */
+export function isOtpGroup(group: UserGroup): boolean {
+  return (group.customClaims ?? []).some(
+    (c) => c.key === TEAM_CLAIM_KEY && c.value === TEAM_CLAIM_VALUE,
+  );
+}
+
+/** Set of group IDs that belong to the OTP team. */
+export function otpGroupIds(groups: UserGroup[]): Set<string> {
+  return new Set(groups.filter(isOtpGroup).map((g) => g.id));
+}
+
+/** True when a user is a member of at least one OTP-team group. */
+export function isOtpMember(user: PocketUser, otpIds: Set<string>): boolean {
+  return (user.userGroups ?? []).some((g) => otpIds.has(g.id));
+}
+
+/** Read a custom-claim value off a user by key (case-insensitive). */
+export function getClaim(user: PocketUser, key: string): string {
+  const claim = (user.customClaims ?? []).find(
+    (c) => c.key.toLowerCase() === key.toLowerCase(),
+  );
+  return claim?.value ?? "";
+}

--- a/src/lib/pocketid.ts
+++ b/src/lib/pocketid.ts
@@ -112,7 +112,7 @@ export async function pocketIdFetch(
 export async function fetchAllPages<T>(path: string): Promise<T[]> {
   const items: T[] = [];
   let page = 1;
-  let totalPages = 1;
+  let totalPages: number;
   const sep = path.includes("?") ? "&" : "?";
 
   do {


### PR DESCRIPTION
## Überblick

Fügt dem Admin-Dashboard einen **Team**-Bereich hinzu, um OTP-Staff-Konten in der PocketID-Instanz (`auth.onthepixel.net`) zu verwalten.

## Funktionen

- **Liste** der Team-Mitglieder aus `GET /api/users`, gefiltert auf Nutzer, die in einer Gruppe mit dem Custom-Claim `Team=OTP` sind (Abgleich über die Gruppen-**ID**, da Namen im Users-Payload teils veraltet sind). Nutzer mit anderem oder ohne Team (z. B. `fastasfuck`, `moricemc`) werden ausgeblendet.
- **Erstellen** neuer Mitglieder über `POST /api/signup` mit Username, automatisch als verifiziert angelegter E-Mail (`username@onthepixel.net`, editierbar) und **Pflicht-Gruppenauswahl** (nur OTP-Gruppen). Danach werden `Discord-id` und `Minecraft-uuid` über `PUT /api/custom-claims/user/{id}` gesetzt.
- **Löschen** von Mitgliedern über `DELETE /api/users/{id}`.

## Sicherheit / API-Key

Alle Upstream-Aufrufe laufen **serverseitig** über `/api/dashboard/team` und senden den `X-API-KEY`-Header aus der System-Variable `pocketid-apikey` (Fallback `POCKETID_APIKEY`). Der Key gelangt nie in den Browser. Basis-URL optional über `POCKETID_API_URL` überschreibbar.

## Geänderte / neue Dateien

- `src/lib/pocketid.ts` — serverseitiger PocketID-Client (X-API-KEY, Pagination, OTP-Filter-Helfer)
- `src/app/api/dashboard/team/route.ts` — `GET` (Liste + OTP-Gruppen), `POST` (Erstellen)
- `src/app/api/dashboard/team/[id]/route.ts` — `DELETE`
- `src/app/dashboard/team/{page.tsx,team-dashboard.tsx}` — UI (Tabelle, Suche, Erstellen-/Löschen-Modal)
- `src/app/dashboard/layout.tsx` — Sidebar-Eintrag „Team"
- `src/app/dashboard/overview.tsx` — Stat-Karte + Quick-Action
- `.env.example` — `pocketid-apikey` dokumentiert

## Verifikation

- `npm run typecheck` ✅ und `npx prettier --check` ✅ für alle geänderten Dateien.
- Filterlogik gegen die Beispiel-Payloads geprüft: sichtbar u. a. Der0ne, SpireEvent, Basti20999, clemens, Jape, TheJ0na; **nicht** sichtbar kingluc (fastasfuck), AlexEmmet/xlagging/mewjo (moricemc).

> Hinweis: `pocketid-apikey` muss in der Umgebung gesetzt sein, damit die Liste lädt und Mitglieder angelegt werden können.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GuNBVmBmk9Mj3GxJnjyk8C)_