### PR TITLE
fix(auth): send state and nonce in OIDC authorize request

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -2,6 +2,11 @@
 const nextConfig = {
   output: "standalone",
   trailingSlash: true,
+  // Keep trailing-slash canonicalisation for pages, but suppress the
+  // automatic 308 redirect. Otherwise /api/auth/callback/oidc is redirected
+  // to /api/auth/callback/oidc/, which does not match the redirect URI
+  // registered at the OIDC provider (Pocket ID) and breaks the callback.
+  skipTrailingSlashRedirect: true,
   images: {
     loader: "imgix",
     path: "https://cdn.onthepixel.net/",

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -24,6 +24,10 @@ if (
     issuer: process.env.OIDC_ISSUER,
     clientId: process.env.OIDC_CLIENT_ID,
     clientSecret: process.env.OIDC_CLIENT_SECRET,
+    // Explicitly send all three checks. Without this, the custom provider
+    // falls back to "pkce" only, so the authorize URL omits `state` and
+    // `nonce` and Pocket ID rejects the request with `invalid_state`.
+    checks: ["pkce", "state", "nonce"],
   });
 }
 


### PR DESCRIPTION
## Problem

The OIDC login against Pocket ID failed. The authorize URL contained `code_challenge` (PKCE) but **no `state` and no `nonce`**:

```
/authorize?response_type=code&client_id=...&redirect_uri=...&code_challenge=...&code_challenge_method=S256&scope=openid+profile+email
```

Pocket ID rejected this with `error=invalid_state` ("The state is missing or does not have enough characters …") and redirected back with an empty `state=` and no `iss`. Auth.js then threw `CallbackRouteError` / `response parameter "iss" (issuer) missing` — a downstream symptom, ending on `/api/auth/error?error=Configuration` (500).

## Root cause

The custom OIDC provider in `src/auth.ts` had **no explicit `checks`** option. Auth.js therefore fell back to its minimal default (`["pkce"]`), which omits `state` and `nonce`.

## Changes

- **`src/auth.ts`**: set `checks: ["pkce", "state", "nonce"]` on the OIDC provider so all three parameters are emitted in the authorize request.
- **`next.config.mjs`**: add `skipTrailingSlashRedirect: true`. With `trailingSlash: true`, Next.js was issuing a fragile 308 from `/api/auth/callback/oidc` to `/api/auth/callback/oidc/`, which does not match the redirect URI registered at Pocket ID. This suppresses the automatic redirect while keeping trailing-slash link canonicalisation for pages.

## Already correct (no change needed)

- `trustHost: true` is already set in `src/auth.ts`.
- `src/middleware.ts` matcher already excludes `api`, so `/api/auth/*` is not intercepted or stripped of query params.

## Requires verification outside the repo (Coolify env)

- `AUTH_URL=https://onthepixel.net` (not `localhost:3000`)
- `AUTH_SECRET` is set

## Acceptance

After the fix the authorize URL contains `state=` and `nonce=`, and the login runs through to the session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017vJQPnepq7Z2nTxbyxKL14)_