### PR TITLE
feat(dashboard): edit team members

### DIFF
--- a/src/app/api/dashboard/team/[id]/route.ts
+++ b/src/app/api/dashboard/team/[id]/route.ts
@@ -1,10 +1,123 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/auth";
-import { pocketIdFetch, PocketIdError } from "@/lib/pocketid";
+import {
+  pocketIdFetch,
+  fetchAllPages,
+  otpGroupIds,
+  PocketIdError,
+  type PocketUser,
+  type UserGroup,
+} from "@/lib/pocketid";
 
 async function checkAuth() {
   const session = await auth();
   return !!session;
+}
+
+function handleError(e: unknown) {
+  if (e instanceof PocketIdError)
+    return NextResponse.json(
+      { error: e.message, detail: e.body },
+      { status: e.status >= 400 ? e.status : 500 },
+    );
+  return NextResponse.json({ error: String(e) }, { status: 500 });
+}
+
+/** PUT — update an existing team member in PocketID. */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  if (!id)
+    return NextResponse.json({ error: "Missing user id" }, { status: 400 });
+
+  try {
+    const body = await req.json();
+
+    // Load the current user and the group catalogue in parallel.
+    const [userRes, groups] = await Promise.all([
+      pocketIdFetch(`/api/users/${id}`),
+      fetchAllPages<UserGroup>("/api/user-groups"),
+    ]);
+    const current = (await userRes.json()) as PocketUser;
+    const otpIds = otpGroupIds(groups);
+
+    // Resolve the target group set: OTP groups come from the request, every
+    // non-OTP group the user already belongs to is preserved untouched.
+    let newGroupIds: string[] | null = null;
+    if (Array.isArray(body.groupIds)) {
+      const selectedOtp = body.groupIds
+        .map((g: unknown) => String(g))
+        .filter((g: string) => otpIds.has(g));
+      if (selectedOtp.length === 0)
+        return NextResponse.json(
+          { error: "Mindestens eine Gruppe muss ausgewählt werden." },
+          { status: 400 },
+        );
+      const keptNonOtp = (current.userGroups ?? [])
+        .map((g) => g.id)
+        .filter((gid) => !otpIds.has(gid));
+      newGroupIds = Array.from(new Set([...keptNonOtp, ...selectedOtp]));
+    }
+
+    // 1) Core user fields (mirrors the create payload shape).
+    const email =
+      body.email !== undefined
+        ? String(body.email).trim()
+        : (current.email ?? "");
+    const displayName =
+      body.displayName !== undefined
+        ? String(body.displayName).trim() || current.username
+        : (current.displayName ?? current.username);
+    const disabled =
+      body.disabled !== undefined ? !!body.disabled : !!current.disabled;
+
+    await pocketIdFetch(`/api/users/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        username: current.username,
+        email,
+        emailVerified: current.emailVerified ?? true,
+        displayName,
+        disabled,
+        isAdmin: current.isAdmin ?? false,
+      }),
+    });
+
+    // 2) Group membership.
+    if (newGroupIds) {
+      await pocketIdFetch(`/api/users/${id}/user-groups`, {
+        method: "PUT",
+        body: JSON.stringify({ userGroupIds: newGroupIds }),
+      });
+    }
+
+    // 3) Custom claims — rebuild Discord/Minecraft while preserving any others.
+    if (body.discordId !== undefined || body.minecraftUuid !== undefined) {
+      const managed = new Set(["discord-id", "minecraft-uuid"]);
+      const claims = (current.customClaims ?? []).filter(
+        (c) => !managed.has(c.key.toLowerCase()),
+      );
+      const discordId = String(body.discordId ?? "").trim();
+      const minecraftUuid = String(body.minecraftUuid ?? "").trim();
+      if (discordId) claims.push({ key: "Discord-id", value: discordId });
+      if (minecraftUuid)
+        claims.push({ key: "Minecraft-uuid", value: minecraftUuid });
+
+      await pocketIdFetch(`/api/custom-claims/user/${id}`, {
+        method: "PUT",
+        body: JSON.stringify(claims),
+      });
+    }
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return handleError(e);
+  }
 }
 
 /** DELETE — remove a team member from PocketID. */
@@ -23,11 +136,6 @@ export async function DELETE(
     await pocketIdFetch(`/api/users/${id}`, { method: "DELETE" });
     return NextResponse.json({ ok: true });
   } catch (e) {
-    if (e instanceof PocketIdError)
-      return NextResponse.json(
-        { error: e.message, detail: e.body },
-        { status: e.status >= 400 ? e.status : 500 },
-      );
-    return NextResponse.json({ error: String(e) }, { status: 500 });
+    return handleError(e);
   }
 }

--- a/src/app/dashboard/team/team-dashboard.tsx
+++ b/src/app/dashboard/team/team-dashboard.tsx
@@ -13,6 +13,7 @@ import {
   UserPlus,
   Shield,
   Save,
+  Pencil,
 } from "lucide-react";
 import { FaDiscord } from "react-icons/fa";
 import AuthGuard from "../auth-guard";
@@ -229,6 +230,205 @@ function CreateModal({
   );
 }
 
+/* --- Edit member modal --- */
+function EditModal({
+  member,
+  groups,
+  onClose,
+  onSaved,
+}: {
+  member: Member;
+  groups: Group[];
+  onClose: () => void;
+  onSaved: (msg: string) => void;
+}) {
+  const [displayName, setDisplayName] = useState(member.displayName);
+  const [email, setEmail] = useState(member.email);
+  const [minecraftUuid, setMinecraftUuid] = useState(member.minecraftUuid);
+  const [discordId, setDiscordId] = useState(member.discordId);
+  const [disabled, setDisabled] = useState(member.disabled);
+  const [groupIds, setGroupIds] = useState<string[]>(
+    member.groups.map((g) => g.id),
+  );
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const toggleGroup = (id: string) =>
+    setGroupIds((prev) =>
+      prev.includes(id) ? prev.filter((g) => g !== id) : [...prev, id],
+    );
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (groupIds.length === 0)
+      return setError("Mindestens eine Gruppe muss ausgewählt werden.");
+    setLoading(true);
+    try {
+      const res = await fetch(`/api/dashboard/team/${member.id}`, {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          displayName: displayName.trim(),
+          email: email.trim(),
+          minecraftUuid: minecraftUuid.trim(),
+          discordId: discordId.trim(),
+          disabled,
+          groupIds,
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok)
+        throw new Error(
+          data.detail || data.error || "Speichern fehlgeschlagen.",
+        );
+      onSaved(`${member.username} wurde aktualisiert.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-lg rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-blue-500/15">
+            <Pencil size={17} className="text-blue-400" />
+          </div>
+          <div>
+            <p className="font-semibold text-white">
+              {member.username} bearbeiten
+            </p>
+            <p className="text-xs text-white/40">
+              Ändert das Konto in PocketID.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="ml-auto rounded-md p-1 text-white/30 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <Field label="Anzeigename">
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              placeholder={member.username}
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-blue-500/40 focus:ring-1 focus:ring-blue-500/20"
+              autoFocus
+            />
+          </Field>
+
+          <Field label="E-Mail">
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="username@onthepixel.net"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-blue-500/40 focus:ring-1 focus:ring-blue-500/20"
+            />
+          </Field>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Minecraft-UUID">
+              <input
+                value={minecraftUuid}
+                onChange={(e) => setMinecraftUuid(e.target.value)}
+                placeholder="b35d0c41-37e8-…"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-blue-500/40 focus:ring-1 focus:ring-blue-500/20"
+              />
+            </Field>
+            <Field label="Discord-ID">
+              <input
+                value={discordId}
+                onChange={(e) => setDiscordId(e.target.value)}
+                placeholder="1279066016005099536"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-blue-500/40 focus:ring-1 focus:ring-blue-500/20"
+              />
+            </Field>
+          </div>
+
+          <Field label="Gruppen">
+            <div className="flex flex-wrap gap-2">
+              {groups.map((g) => {
+                const active = groupIds.includes(g.id);
+                return (
+                  <button
+                    key={g.id}
+                    type="button"
+                    onClick={() => toggleGroup(g.id)}
+                    className={`inline-flex items-center gap-1.5 rounded-lg border px-3 py-1.5 text-xs font-medium transition-colors ${
+                      active
+                        ? "border-green-500/40 bg-green-500/15 text-green-300"
+                        : "border-white/10 bg-white/5 text-white/40 hover:bg-white/10"
+                    }`}
+                  >
+                    <Shield size={12} /> {g.friendlyName}
+                  </button>
+                );
+              })}
+            </div>
+          </Field>
+
+          <label className="flex cursor-pointer items-center justify-between rounded-lg border border-white/10 bg-white/5 px-3 py-2.5">
+            <div>
+              <p className="text-sm font-medium text-white">
+                Konto deaktiviert
+              </p>
+              <p className="text-xs text-white/40">
+                Deaktivierte Konten können sich nicht anmelden.
+              </p>
+            </div>
+            <input
+              type="checkbox"
+              checked={disabled}
+              onChange={(e) => setDisabled(e.target.checked)}
+              className="h-4 w-4 accent-red-500"
+            />
+          </label>
+
+          {error && (
+            <div className="flex items-start gap-2.5 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
+              <AlertCircle size={15} className="mt-0.5 shrink-0" />
+              <span className="break-words">{error}</span>
+            </div>
+          )}
+
+          <div className="mt-1 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 transition-colors hover:bg-white/5"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-blue-500 py-2 text-sm font-semibold text-white transition-colors hover:bg-blue-400 disabled:opacity-60"
+            >
+              {loading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Save size={14} />
+              )}
+              Speichern
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
 /* --- Delete modal --- */
 function DeleteModal({
   member,
@@ -290,9 +490,11 @@ function DeleteModal({
 /* --- Table row --- */
 function MemberRow({
   member,
+  onEdit,
   onDelete,
 }: {
   member: Member;
+  onEdit: (m: Member) => void;
   onDelete: (m: Member) => void;
 }) {
   return (
@@ -356,12 +558,20 @@ function MemberRow({
         )}
       </td>
       <td className="py-3 pr-4 pl-3">
-        <button
-          onClick={() => onDelete(member)}
-          className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 transition-colors hover:bg-red-500/10 hover:text-red-400"
-        >
-          <Trash2 size={12} />
-        </button>
+        <div className="flex items-center gap-1">
+          <button
+            onClick={() => onEdit(member)}
+            className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 transition-colors hover:bg-blue-500/10 hover:text-blue-400"
+          >
+            <Pencil size={12} />
+          </button>
+          <button
+            onClick={() => onDelete(member)}
+            className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 transition-colors hover:bg-red-500/10 hover:text-red-400"
+          >
+            <Trash2 size={12} />
+          </button>
+        </div>
       </td>
     </tr>
   );
@@ -375,6 +585,7 @@ function TeamDashboardContent() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
   const [showCreate, setShowCreate] = useState(false);
+  const [editTarget, setEditTarget] = useState<Member | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Member | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [toast, setToast] = useState<string | null>(null);
@@ -451,6 +662,18 @@ function TeamDashboardContent() {
           onClose={() => setShowCreate(false)}
           onCreated={(msg) => {
             setShowCreate(false);
+            load();
+            showToast(msg);
+          }}
+        />
+      )}
+      {editTarget && (
+        <EditModal
+          member={editTarget}
+          groups={groups}
+          onClose={() => setEditTarget(null)}
+          onSaved={(msg) => {
+            setEditTarget(null);
             load();
             showToast(msg);
           }}
@@ -557,7 +780,12 @@ function TeamDashboardContent() {
               </thead>
               <tbody>
                 {filtered.map((m) => (
-                  <MemberRow key={m.id} member={m} onDelete={setDeleteTarget} />
+                  <MemberRow
+                    key={m.id}
+                    member={m}
+                    onEdit={setEditTarget}
+                    onDelete={setDeleteTarget}
+                  />
                 ))}
               </tbody>
             </table>


### PR DESCRIPTION
## Was

Ergänzt das Team-Dashboard um eine **Bearbeiten-Funktion** für bestehende Team-Mitglieder – Gegenstück zum bereits vorhandenen Anlegen und Löschen.

## Änderungen

**API – `PUT /api/dashboard/team/[id]`**
- Aktualisiert Anzeigename, E-Mail und Deaktiviert-Status über `PUT /api/users/{id}`.
- Setzt die Gruppenzugehörigkeit über `PUT /api/users/{id}/user-groups`. Es werden nur OTP-Gruppen aus der Anfrage übernommen; **nicht-OTP-Gruppen des Nutzers bleiben unangetastet**.
- Schreibt die Custom Claims `Discord-id` / `Minecraft-uuid` über `PUT /api/custom-claims/user/{id}` neu und **erhält dabei alle übrigen Claims**.
- Validiert, dass mindestens eine OTP-Gruppe ausgewählt bleibt (verhindert versehentliches Entfernen aus dem Team).

**UI – `team-dashboard.tsx`**
- Neues `EditModal` mit Feldern für Anzeigename, E-Mail, Minecraft-UUID, Discord-ID, Gruppen (Multi-Select als Toggle-Chips) und einem Deaktiviert-Schalter.
- Pro Tabellenzeile ein Stift-Icon, das das Modal mit vorbefüllten Werten öffnet.

## Test

- `tsc --noEmit` läuft fehlerfrei durch.
- Prettier-Formatierung angewendet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011HWF1sR5hp5dqSpJxedDAL)_