### PR TITLE
feat(dashboard): create and edit OTP team groups

### DIFF
--- a/src/app/api/dashboard/team/groups/[id]/route.ts
+++ b/src/app/api/dashboard/team/groups/[id]/route.ts
@@ -1,0 +1,84 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  pocketIdFetch,
+  isOtpGroup,
+  OTP_TEAM_CLAIM,
+  PocketIdError,
+  type CustomClaim,
+  type UserGroup,
+} from "@/lib/pocketid";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+function handleError(e: unknown) {
+  if (e instanceof PocketIdError)
+    return NextResponse.json(
+      { error: e.message, detail: e.body },
+      { status: e.status >= 400 ? e.status : 500 },
+    );
+  return NextResponse.json({ error: String(e) }, { status: 500 });
+}
+
+/** PUT — update an existing OTP-team group's name, prefix and weight. */
+export async function PUT(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  if (!id)
+    return NextResponse.json({ error: "Missing group id" }, { status: 400 });
+
+  try {
+    const body = await req.json();
+    const name = String(body.name ?? "").trim();
+    const prefix = String(body.prefix ?? "").trim();
+    const weight = String(body.weight ?? "").trim();
+
+    if (!name)
+      return NextResponse.json(
+        { error: "Name ist erforderlich." },
+        { status: 400 },
+      );
+
+    // Load the current group and confirm it is an OTP-team group.
+    const groupRes = await pocketIdFetch(`/api/user-groups/${id}`);
+    const current = (await groupRes.json()) as UserGroup;
+    if (!isOtpGroup(current))
+      return NextResponse.json({ error: "Keine OTP-Gruppe." }, { status: 403 });
+
+    // 1) Update the display name (the technical `name` slug stays stable).
+    await pocketIdFetch(`/api/user-groups/${id}`, {
+      method: "PUT",
+      body: JSON.stringify({
+        name: current.name,
+        friendlyName: name,
+      }),
+    });
+
+    // 2) Rebuild claims: keep the OTP marker and any unrelated claims, replace
+    //    prefix / weight with the submitted values.
+    const managed = new Set(["team", "prefix", "weight"]);
+    const claims: CustomClaim[] = (current.customClaims ?? []).filter(
+      (c) => !managed.has(c.key.toLowerCase()),
+    );
+    claims.push(OTP_TEAM_CLAIM);
+    if (prefix) claims.push({ key: "prefix", value: prefix });
+    if (weight) claims.push({ key: "weight", value: weight });
+
+    await pocketIdFetch(`/api/custom-claims/user-group/${id}`, {
+      method: "PUT",
+      body: JSON.stringify(claims),
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/src/app/api/dashboard/team/groups/route.ts
+++ b/src/app/api/dashboard/team/groups/route.ts
@@ -1,0 +1,83 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import {
+  pocketIdFetch,
+  OTP_TEAM_CLAIM,
+  slugifyGroupName,
+  PocketIdError,
+  type CustomClaim,
+  type UserGroup,
+} from "@/lib/pocketid";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+function handleError(e: unknown) {
+  if (e instanceof PocketIdError)
+    return NextResponse.json(
+      { error: e.message, detail: e.body },
+      { status: e.status >= 400 ? e.status : 500 },
+    );
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error("[team groups route]", e);
+  return NextResponse.json({ error: msg }, { status: 500 });
+}
+
+/** POST — create a new OTP-team group (marked with the `Team=OTP` claim). */
+export async function POST(req: NextRequest) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    const body = await req.json();
+    const name = String(body.name ?? "").trim();
+    const prefix = String(body.prefix ?? "").trim();
+    const weight = String(body.weight ?? "").trim();
+
+    if (!name)
+      return NextResponse.json(
+        { error: "Name ist erforderlich." },
+        { status: 400 },
+      );
+
+    // 1) Create the group. `name` is the technical slug, `friendlyName` the
+    //    display label the user typed.
+    const res = await pocketIdFetch("/api/user-groups", {
+      method: "POST",
+      body: JSON.stringify({
+        name: slugifyGroupName(name),
+        friendlyName: name,
+      }),
+    });
+    const created = (await res.json()) as UserGroup;
+
+    // 2) Mark it as an OTP group and attach the prefix / weight claims.
+    const claims: CustomClaim[] = [OTP_TEAM_CLAIM];
+    if (prefix) claims.push({ key: "prefix", value: prefix });
+    if (weight) claims.push({ key: "weight", value: weight });
+
+    let claimsWarning: string | undefined;
+    if (created?.id) {
+      try {
+        await pocketIdFetch(`/api/custom-claims/user-group/${created.id}`, {
+          method: "PUT",
+          body: JSON.stringify(claims),
+        });
+      } catch (e) {
+        claimsWarning =
+          e instanceof PocketIdError
+            ? `Gruppe angelegt, aber Claims fehlgeschlagen: ${e.body || e.message}`
+            : `Gruppe angelegt, aber Claims fehlgeschlagen: ${String(e)}`;
+      }
+    }
+
+    return NextResponse.json(
+      { data: created, warning: claimsWarning },
+      { status: 201 },
+    );
+  } catch (e) {
+    return handleError(e);
+  }
+}

--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -6,6 +6,7 @@ import {
   otpGroupIds,
   isOtpMember,
   getClaim,
+  readClaim,
   PocketIdError,
   type PocketUser,
   type UserGroup,
@@ -42,7 +43,13 @@ export async function GET() {
     const otpIds = otpGroupIds(groups);
     const otpGroups = groups
       .filter((g) => otpIds.has(g.id))
-      .map((g) => ({ id: g.id, name: g.name, friendlyName: g.friendlyName }));
+      .map((g) => ({
+        id: g.id,
+        name: g.name,
+        friendlyName: g.friendlyName,
+        prefix: readClaim(g.customClaims, "prefix"),
+        weight: readClaim(g.customClaims, "weight"),
+      }));
 
     const members = users
       .filter((u) => isOtpMember(u, otpIds))

--- a/src/app/dashboard/team/team-dashboard.tsx
+++ b/src/app/dashboard/team/team-dashboard.tsx
@@ -14,6 +14,8 @@ import {
   Shield,
   Save,
   Pencil,
+  Tag,
+  Weight,
 } from "lucide-react";
 import { FaDiscord } from "react-icons/fa";
 import AuthGuard from "../auth-guard";
@@ -22,6 +24,8 @@ interface Group {
   id: string;
   friendlyName: string;
   name?: string;
+  prefix?: string;
+  weight?: string;
 }
 
 interface Member {
@@ -487,6 +491,233 @@ function DeleteModal({
   );
 }
 
+/* --- Create / edit group modal --- */
+function GroupModal({
+  group,
+  onClose,
+  onSaved,
+}: {
+  group: Group | null;
+  onClose: () => void;
+  onSaved: (msg: string) => void;
+}) {
+  const editing = !!group;
+  const [name, setName] = useState(group?.friendlyName ?? "");
+  const [prefix, setPrefix] = useState(group?.prefix ?? "");
+  const [weight, setWeight] = useState(group?.weight ?? "");
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const submit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError(null);
+    if (!name.trim()) return setError("Name ist erforderlich.");
+    setLoading(true);
+    try {
+      const url = editing
+        ? `/api/dashboard/team/groups/${group!.id}`
+        : "/api/dashboard/team/groups";
+      const res = await fetch(url, {
+        method: editing ? "PUT" : "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: name.trim(),
+          prefix: prefix.trim(),
+          weight: weight.trim(),
+        }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok)
+        throw new Error(
+          data.detail || data.error || "Speichern fehlgeschlagen.",
+        );
+      onSaved(
+        data.warning ??
+          (editing
+            ? `Gruppe "${name}" wurde aktualisiert.`
+            : `Gruppe "${name}" wurde angelegt.`),
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : String(err));
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div
+        className="absolute inset-0 bg-black/70 backdrop-blur-sm"
+        onClick={onClose}
+      />
+      <div className="relative z-10 w-full max-w-lg rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-xl bg-purple-500/15">
+            <Shield size={18} className="text-purple-400" />
+          </div>
+          <div>
+            <p className="font-semibold text-white">
+              {editing ? `${group!.friendlyName} bearbeiten` : "Neue Gruppe"}
+            </p>
+            <p className="text-xs text-white/40">
+              OTP-Team-Gruppe in PocketID.
+            </p>
+          </div>
+          <button
+            onClick={onClose}
+            className="ml-auto rounded-md p-1 text-white/30 transition-colors hover:bg-white/10 hover:text-white"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        <form onSubmit={submit} className="flex flex-col gap-4">
+          <Field label="Name *">
+            <input
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="z. B. Moderator"
+              className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-purple-500/40 focus:ring-1 focus:ring-purple-500/20"
+              autoFocus
+            />
+          </Field>
+
+          <div className="grid gap-4 sm:grid-cols-2">
+            <Field label="Prefix">
+              <input
+                value={prefix}
+                onChange={(e) => setPrefix(e.target.value)}
+                placeholder="z. B. &7[Mod]"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-purple-500/40 focus:ring-1 focus:ring-purple-500/20"
+              />
+            </Field>
+            <Field label="Weight">
+              <input
+                type="number"
+                value={weight}
+                onChange={(e) => setWeight(e.target.value)}
+                placeholder="z. B. 100"
+                className="w-full rounded-lg border border-white/10 bg-white/5 px-3 py-2 text-sm text-white placeholder-white/20 transition-all outline-none focus:border-purple-500/40 focus:ring-1 focus:ring-purple-500/20"
+              />
+            </Field>
+          </div>
+
+          {error && (
+            <div className="flex items-start gap-2.5 rounded-xl border border-red-500/20 bg-red-500/10 p-3 text-sm text-red-300">
+              <AlertCircle size={15} className="mt-0.5 shrink-0" />
+              <span className="break-words">{error}</span>
+            </div>
+          )}
+
+          <div className="mt-1 flex gap-3">
+            <button
+              type="button"
+              onClick={onClose}
+              className="flex-1 rounded-lg border border-white/10 py-2 text-sm text-white/60 transition-colors hover:bg-white/5"
+            >
+              Abbrechen
+            </button>
+            <button
+              type="submit"
+              disabled={loading}
+              className="flex flex-1 items-center justify-center gap-2 rounded-lg bg-purple-500 py-2 text-sm font-semibold text-white transition-colors hover:bg-purple-400 disabled:opacity-60"
+            >
+              {loading ? (
+                <Loader2 size={14} className="animate-spin" />
+              ) : (
+                <Save size={14} />
+              )}
+              {editing ? "Speichern" : "Erstellen"}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}
+
+/* --- Groups panel --- */
+function GroupsPanel({
+  groups,
+  onCreate,
+  onEdit,
+}: {
+  groups: Group[];
+  onCreate: () => void;
+  onEdit: (g: Group) => void;
+}) {
+  return (
+    <div className="mb-8">
+      <div className="mb-3 flex items-center justify-between">
+        <div>
+          <h2
+            className="text-lg font-bold text-white"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
+            Gruppen
+          </h2>
+          <p className="mt-0.5 text-sm text-white/40">
+            {groups.length} OTP-Gruppen
+          </p>
+        </div>
+        <button
+          onClick={onCreate}
+          className="flex h-9 items-center gap-2 rounded-lg border border-purple-500/30 bg-purple-500/10 px-4 text-sm font-semibold text-purple-300 transition-colors hover:bg-purple-500/20"
+        >
+          <Plus size={15} /> Neue Gruppe
+        </button>
+      </div>
+
+      {groups.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 rounded-xl border border-white/5 bg-white/[0.02] py-10">
+          <Shield size={28} className="text-white/10" />
+          <p className="text-sm text-white/30">Keine OTP-Gruppen.</p>
+        </div>
+      ) : (
+        <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+          {groups.map((g) => (
+            <div
+              key={g.id}
+              className="group flex items-start justify-between gap-3 rounded-xl border border-white/5 bg-white/[0.02] p-4 transition-colors hover:bg-white/[0.04]"
+            >
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <Shield size={14} className="shrink-0 text-purple-400" />
+                  <p className="truncate text-sm font-medium text-white">
+                    {g.friendlyName}
+                  </p>
+                </div>
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {g.prefix ? (
+                    <span className="inline-flex items-center gap-1 rounded-md bg-white/5 px-2 py-1 font-mono text-xs text-white/60">
+                      <Tag size={11} /> {g.prefix}
+                    </span>
+                  ) : null}
+                  {g.weight ? (
+                    <span className="inline-flex items-center gap-1 rounded-md bg-white/5 px-2 py-1 text-xs text-white/60">
+                      <Weight size={11} /> {g.weight}
+                    </span>
+                  ) : null}
+                  {!g.prefix && !g.weight && (
+                    <span className="text-xs text-white/20">
+                      kein Prefix / Weight
+                    </span>
+                  )}
+                </div>
+              </div>
+              <button
+                onClick={() => onEdit(g)}
+                className="shrink-0 rounded-md p-1.5 text-white/30 transition-colors hover:bg-purple-500/10 hover:text-purple-400"
+              >
+                <Pencil size={13} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
 /* --- Table row --- */
 function MemberRow({
   member,
@@ -588,6 +819,9 @@ function TeamDashboardContent() {
   const [editTarget, setEditTarget] = useState<Member | null>(null);
   const [deleteTarget, setDeleteTarget] = useState<Member | null>(null);
   const [deleteLoading, setDeleteLoading] = useState(false);
+  const [groupModal, setGroupModal] = useState<{ group: Group | null } | null>(
+    null,
+  );
   const [toast, setToast] = useState<string | null>(null);
 
   const showToast = (msg: string) => {
@@ -687,6 +921,17 @@ function TeamDashboardContent() {
           loading={deleteLoading}
         />
       )}
+      {groupModal && (
+        <GroupModal
+          group={groupModal.group}
+          onClose={() => setGroupModal(null)}
+          onSaved={(msg) => {
+            setGroupModal(null);
+            load();
+            showToast(msg);
+          }}
+        />
+      )}
 
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
@@ -736,6 +981,14 @@ function TeamDashboardContent() {
           <AlertCircle size={15} className="mt-0.5 shrink-0" />
           <span className="break-words">{loadError}</span>
         </div>
+      )}
+
+      {!loading && (
+        <GroupsPanel
+          groups={groups}
+          onCreate={() => setGroupModal({ group: null })}
+          onEdit={(g) => setGroupModal({ group: g })}
+        />
       )}
 
       <div className="overflow-hidden rounded-xl border border-white/5 bg-white/[0.02]">

--- a/src/lib/pocketid.ts
+++ b/src/lib/pocketid.ts
@@ -128,6 +128,12 @@ export async function fetchAllPages<T>(path: string): Promise<T[]> {
   return items;
 }
 
+/** The custom claim that marks a group as belonging to the OTP team. */
+export const OTP_TEAM_CLAIM: CustomClaim = {
+  key: TEAM_CLAIM_KEY,
+  value: TEAM_CLAIM_VALUE,
+};
+
 /** True when a group carries the `Team=OTP` custom claim. */
 export function isOtpGroup(group: UserGroup): boolean {
   return (group.customClaims ?? []).some(
@@ -145,10 +151,31 @@ export function isOtpMember(user: PocketUser, otpIds: Set<string>): boolean {
   return (user.userGroups ?? []).some((g) => otpIds.has(g.id));
 }
 
-/** Read a custom-claim value off a user by key (case-insensitive). */
-export function getClaim(user: PocketUser, key: string): string {
-  const claim = (user.customClaims ?? []).find(
+/** Read a custom-claim value from any claim list by key (case-insensitive). */
+export function readClaim(
+  claims: CustomClaim[] | undefined,
+  key: string,
+): string {
+  const claim = (claims ?? []).find(
     (c) => c.key.toLowerCase() === key.toLowerCase(),
   );
   return claim?.value ?? "";
+}
+
+/** Read a custom-claim value off a user by key (case-insensitive). */
+export function getClaim(user: PocketUser, key: string): string {
+  return readClaim(user.customClaims, key);
+}
+
+/**
+ * Slugify a display name into a PocketID group `name` (lowercase, digits and
+ * single hyphens). Falls back to `group` when nothing usable remains.
+ */
+export function slugifyGroupName(input: string): string {
+  const slug = input
+    .toLowerCase()
+    .normalize("NFKD")
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "group";
 }


### PR DESCRIPTION
## Was

Erweitert das Team-Dashboard um **Gruppen-Verwaltung** für OTP-Gruppen (Gruppen mit dem `Team=OTP`-Claim): Anlegen und Bearbeiten, jeweils mit den Feldern **Name**, **Prefix** und **Weight**.

## Änderungen

**UI – `team-dashboard.tsx`**
- Neues Panel „Gruppen" oberhalb der Mitglieder-Tabelle, das alle OTP-Gruppen mit Prefix und Weight als Karten anzeigt.
- „Neue Gruppe"-Button und pro Karte ein Stift-Icon zum Bearbeiten.
- Gemeinsames `GroupModal` für Anlegen/Bearbeiten mit den Feldern Name (Pflicht), Prefix und Weight (numerisch).

**API**
- `POST /api/dashboard/team/groups` — legt eine Gruppe an, markiert sie mit `Team=OTP` und setzt die `prefix`/`weight`-Custom-Claims. Der technische `name`-Slug wird aus dem Anzeigenamen abgeleitet.
- `PUT /api/dashboard/team/groups/[id]` — aktualisiert den Anzeigenamen und schreibt `prefix`/`weight` neu. Der OTP-Marker sowie alle übrigen Claims bleiben erhalten; der technische Slug bleibt stabil. Bearbeiten ist auf OTP-Gruppen beschränkt.
- `GET /api/dashboard/team` liefert nun `prefix` und `weight` pro OTP-Gruppe mit.

**`lib/pocketid.ts`**
- Neue Helfer `readClaim` (Claim aus beliebiger Claim-Liste lesen) und `slugifyGroupName`; der OTP-Team-Claim wird als `OTP_TEAM_CLAIM` exportiert.

## Annahmen

- `prefix` und `weight` werden als Group-Custom-Claims mit exakt diesen (kleingeschriebenen) Schlüsseln gespeichert.
- Das eine „Name"-Feld setzt beim Anlegen den Anzeigenamen (`friendlyName`) und einen daraus abgeleiteten technischen `name`-Slug; beim Bearbeiten bleibt der Slug unverändert.

## Test

- `tsc --noEmit` läuft fehlerfrei durch.
- Prettier-Formatierung angewendet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011HWF1sR5hp5dqSpJxedDAL)_