### PR TITLE
chore(deps): update lucide-react to ^1.25.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "gsap": "^3.15.0",
-        "lucide-react": "^1.24.0",
+        "lucide-react": "^1.25.0",
         "next": "^16.2.10",
         "next-auth": "^5.0.0-beta.31",
         "postgres": "^3.4.9",
@@ -9129,9 +9129,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
-      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.24.0",
+    "lucide-react": "^1.25.0",
     "next": "^16.2.10",
     "next-auth": "^5.0.0-beta.31",
     "postgres": "^3.4.9",


### PR DESCRIPTION
## Summary\n\n- Update `lucide-react` from `^1.24.0` to `^1.25.0` (minor version bump)\n- Regenerated `package-lock.json` with the updated dependency\n\n## Notes\n\n- **TypeScript 7** (`^7.0.2`) is available but was **not** upgraded because `@typescript-eslint/parser@8.64.0` only supports TypeScript `<6.1.0`. This update can be revisited once `@typescript-eslint` adds TS 7 support.\n- All other dependencies were already at their latest compatible versions.\n- Type-check (`tsc --noEmit`) passes with no errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vfkz8FyJPqEt5fto6ywzQ1)_