### PR TITLE
chore(deps): update all dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,12 +10,12 @@
       "dependencies": {
         "@hcaptcha/react-hcaptcha": "^2.0.2",
         "@opennextjs/cloudflare": "^1.20.1",
-        "@radix-ui/react-avatar": "^1.2.2",
-        "@radix-ui/react-dialog": "^1.1.19",
+        "@radix-ui/react-avatar": "^1.2.3",
+        "@radix-ui/react-dialog": "^1.1.20",
         "@radix-ui/react-icons": "^1.3.2",
-        "@radix-ui/react-label": "^2.1.11",
+        "@radix-ui/react-label": "^2.1.12",
         "@radix-ui/react-slot": "^1.3.0",
-        "@radix-ui/react-switch": "^1.3.3",
+        "@radix-ui/react-switch": "^1.3.4",
         "@tabler/icons-react": "^3.45.0",
         "@tailwindcss/typography": "^0.5.20",
         "@vercel/analytics": "^2.0.1",
@@ -23,7 +23,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "gsap": "^3.15.0",
-        "lucide-react": "^1.24.0",
+        "lucide-react": "^1.25.0",
         "next": "^16.2.10",
         "next-auth": "^5.0.0-beta.31",
         "postgres": "^3.4.9",
@@ -48,7 +48,7 @@
         "eslint": "^10.7.0",
         "eslint-config-next": "^16.2.10",
         "eslint-plugin-drizzle": "^0.2.3",
-        "postcss": "^8.5.19",
+        "postcss": "^8.5.20",
         "prettier": "^3.9.5",
         "prettier-plugin-tailwindcss": "^0.8.1",
         "tailwindcss": "^4.3.3",
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260710.1.tgz",
-      "integrity": "sha512-OqJl2eWF5+y9jarMm3YqqCTUe7Hd4ihogX5jyRU8iaAgOVyDr/Bk6aXpPCVUi1/MHzO93a18R/TmSTtzmB0sQw==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260714.1.tgz",
+      "integrity": "sha512-ZWXqAN8G7Cx9hMRQuk+59ziJhR3j1F4iO+Qs8aHdfKZ3Dq5Yi/57xvkJTgCGBnW1YU/L78r8f6HEy51bwbTpNw==",
       "cpu": [
         "x64"
       ],
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260710.1.tgz",
-      "integrity": "sha512-MYBqWgUblO+VlGvO73zYsH3hB9tdRj+yLyt5IHDFWryipb2l1efmNiWtAOkIhSRfypqLYGFrfpaDm2Hg00XVKw==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-tueWxWC3wyCbMG6zRAxsMXX0YLgrRWbiAPYFQ2uJ7dUH8G+5E7UTWaQS9B1HdJ0bpKFW1NWxhs1o2noKVFSUYg==",
       "cpu": [
         "arm64"
       ],
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260710.1.tgz",
-      "integrity": "sha512-lVWUgqI8qrkqvaCBGElu1kdaUFdAvaS2RD8K4qkCFP9hI3f5TCXumEs5qWSeZkvKum0+X/uJZ5hBFWsYI5SmoQ==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260714.1.tgz",
+      "integrity": "sha512-1VChTZRb0l0F7R4e1G5RtLKV4oFi6x+rQgxh2+yu887j3l/3TLgatuv1L8/5zhc9gKEhATTxOh0e52Rtd9dDWQ==",
       "cpu": [
         "x64"
       ],
@@ -1538,9 +1538,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260710.1.tgz",
-      "integrity": "sha512-kDwDPItBjAI4JL0df9Fma2N+Qggbm77IB/DnroAkEGQ79fpR80sYMyuB/ZQKyjEk9f48Ocq7HCCLq59qVSyNqA==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260714.1.tgz",
+      "integrity": "sha512-rMm3G+NirG2UdgHIRDdF1asNC6FqgIzZzkRG+VDhhDGcVxAQwvrMT1E38BivEvHr3G04MB4AfhcOczX0+GtRkQ==",
       "cpu": [
         "arm64"
       ],
@@ -1555,9 +1555,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260710.1.tgz",
-      "integrity": "sha512-GcLHy1oN1dfK6g1Z7UDV9f5xMGyTfPwcjWQ0sfWKH31IsoEVCRapnj3IC0PoIrDbnoo6irGPP0CwVs3WzdTajw==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260714.1.tgz",
+      "integrity": "sha512-cGqnU3Hg2YZS/k3SAqrMp1DjpdsyFde72tWltdl6ZT9+SFz/Zrk/8gyTU1TcxC4YApXeNVH5TyU5cOGPgUJ0pg==",
       "cpu": [
         "x64"
       ],
@@ -3323,17 +3323,18 @@
       "peer": true
     },
     "node_modules/@radix-ui/primitive": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.5.tgz",
-      "integrity": "sha512-d86WIWFYNtGA0H/d8exstrTRTp7eWJYlYJbtNofxr/3ljupZYn6EFDG/Qgu/0Kc8v7yMUxySagqJsL1+PdYjWg==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.6.tgz",
+      "integrity": "sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==",
       "license": "MIT"
     },
     "node_modules/@radix-ui/react-avatar": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.2.tgz",
-      "integrity": "sha512-sST0qh8GzOB7besQ3tMLWLyngnRuSk0gc/Hm+667KYKQFCt6Y6ZXv25WlqM7dIDK54ULCh5+CHmk4LIolzfz+A==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-avatar/-/react-avatar-1.2.3.tgz",
+      "integrity": "sha512-peavtnApRB1tABx42tHw+rPU83GSg5tXicMYO/Xi1/lqNcRsF6jkr6L7Njo7gj4q/xtDRDKBkqJvbMtoOMYWtA==",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
         "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
@@ -3386,23 +3387,24 @@
       }
     },
     "node_modules/@radix-ui/react-dialog": {
-      "version": "1.1.19",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.19.tgz",
-      "integrity": "sha512-+HhbN2+YtkRgVirjZ2afMeutQRuGOrdkWR5+EFC58SJojGmtyNQwYzgi6tHBpOxvFHefMtPeHdgtjz0BOGxFQg==",
+      "version": "1.1.20",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.20.tgz",
+      "integrity": "sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/primitive": "1.1.6",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.2.0",
-        "@radix-ui/react-dismissable-layer": "1.1.15",
+        "@radix-ui/react-dismissable-layer": "1.1.16",
         "@radix-ui/react-focus-guards": "1.1.4",
-        "@radix-ui/react-focus-scope": "1.1.12",
+        "@radix-ui/react-focus-scope": "1.1.13",
         "@radix-ui/react-id": "1.1.2",
-        "@radix-ui/react-portal": "1.1.13",
-        "@radix-ui/react-presence": "1.1.7",
+        "@radix-ui/react-portal": "1.1.14",
+        "@radix-ui/react-presence": "1.1.8",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-slot": "1.3.0",
-        "@radix-ui/react-use-controllable-state": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
         "aria-hidden": "^1.2.4",
         "react-remove-scroll": "^2.7.2"
       },
@@ -3422,12 +3424,12 @@
       }
     },
     "node_modules/@radix-ui/react-dismissable-layer": {
-      "version": "1.1.15",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.15.tgz",
-      "integrity": "sha512-b0XaRlzn2QKuo10XyNgi2DAJDf5XC9d1nD3FJcuvCjbR7+4Ad28zmZsLsqx+hvDEzMnRuZaZxZm9gYObV6RmRA==",
+      "version": "1.1.16",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.16.tgz",
+      "integrity": "sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/primitive": "1.1.6",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-primitive": "2.1.7",
         "@radix-ui/react-use-callback-ref": "1.1.2",
@@ -3464,9 +3466,9 @@
       }
     },
     "node_modules/@radix-ui/react-focus-scope": {
-      "version": "1.1.12",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.12.tgz",
-      "integrity": "sha512-jjk/lqTeNL0azUx5ZYzVrl4NgaDIrdzTNE4mABV9yBFI7FQqN7pIgzV1bTleUezP2QiTGA1BFTqY8MegDgWX9A==",
+      "version": "1.1.13",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.13.tgz",
+      "integrity": "sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-compose-refs": "1.1.3",
@@ -3516,9 +3518,9 @@
       }
     },
     "node_modules/@radix-ui/react-label": {
-      "version": "2.1.11",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.11.tgz",
-      "integrity": "sha512-3PKvDDxOn62k0oV1n4QtNtD2vpu+zYjXR7ojLBPaO6SPvhy53yg0vAmgNeBQeJW5rV3dffoRG+HYfLBZuzw0CQ==",
+      "version": "2.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-label/-/react-label-2.1.12.tgz",
+      "integrity": "sha512-dxioNQ7VOrYKKWJIxMRmJPDSWQN0gNCUy3zaqUSBwsuFAiFzI0yLGJr2q3ml07k/HlOk55N8KEfwa1ZgfprJ3w==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.7"
@@ -3539,9 +3541,9 @@
       }
     },
     "node_modules/@radix-ui/react-portal": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.13.tgz",
-      "integrity": "sha512-z3oXfmaHLJTF1wktbjgD6cn9jiEbq3WSondB10LIuIt2m2Ym4iJlrW04/euMwENDdWDdE7z+OuY7Qyp1YpRSwA==",
+      "version": "1.1.14",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.14.tgz",
+      "integrity": "sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-primitive": "2.1.7",
@@ -3563,9 +3565,9 @@
       }
     },
     "node_modules/@radix-ui/react-presence": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.7.tgz",
-      "integrity": "sha512-zBZ4QM5XG3JRanDmqXYf3MD6th4AFXFmgU6KNMFzUaV6F3uw9I5/zjMUvFriSEn5ewo1nxuibvyxJdmLlDcslA==",
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.8.tgz",
+      "integrity": "sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-use-layout-effect": "1.1.2"
@@ -3627,17 +3629,16 @@
       }
     },
     "node_modules/@radix-ui/react-switch": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.3.tgz",
-      "integrity": "sha512-1+mlB4/lxJfk5tgJ4g+R5mUCbRpPE1T9+UsEyeLYbGgMtwiMgmuTnfKz4Mw1nHALHjuwyxw4MLd4cSHn6pNSlQ==",
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-switch/-/react-switch-1.3.4.tgz",
+      "integrity": "sha512-7iGMj1SfZBAc6xRiy0Y3Wr/v52viQeDhOmaM3fNRyNf2nbYooZA3kKoEDGLPtrDv8JitpzcueqdZLusVMojLdQ==",
       "license": "MIT",
       "dependencies": {
-        "@radix-ui/primitive": "1.1.5",
+        "@radix-ui/primitive": "1.1.6",
         "@radix-ui/react-compose-refs": "1.1.3",
         "@radix-ui/react-context": "1.2.0",
         "@radix-ui/react-primitive": "2.1.7",
-        "@radix-ui/react-use-controllable-state": "1.2.3",
-        "@radix-ui/react-use-previous": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.4",
         "@radix-ui/react-use-size": "1.1.2"
       },
       "peerDependencies": {
@@ -3671,11 +3672,12 @@
       }
     },
     "node_modules/@radix-ui/react-use-controllable-state": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
-      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.4.tgz",
+      "integrity": "sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/primitive": "1.1.6",
         "@radix-ui/react-use-effect-event": "0.0.3",
         "@radix-ui/react-use-layout-effect": "1.1.2"
       },
@@ -3726,21 +3728,6 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
       "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@types/react": "*",
-        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
-      },
-      "peerDependenciesMeta": {
-        "@types/react": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@radix-ui/react-use-previous": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-previous/-/react-use-previous-1.1.2.tgz",
-      "integrity": "sha512-IGBQPtRFdhN6MQ8dbegVmBq1LVZluya3F1jWY+puIcQC3MHctRwTDSBWCkL/3ZcnMJLTMJ++Z+ktmvg0F89iCw==",
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "*",
@@ -6528,9 +6515,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.392",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.392.tgz",
-      "integrity": "sha512-1yQq3VQCZRwsnYc67Oc+1fge6Lwtn0hzi6zmEVkB61Zx21kTbwJAW4dFLadl5Rc1tKhG/kSpYXnfiAhu0f0a1g==",
+      "version": "1.5.393",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.393.tgz",
+      "integrity": "sha512-kiDJdIUawuEIcp9XoICKp1iTYDEbgguIPq526N1Q7jIQDeQ3CqoMx71025PI/7E48Ddtw2HuWsVjY7afEgNxmg==",
       "dev": true,
       "license": "ISC"
     },
@@ -6550,9 +6537,9 @@
       }
     },
     "node_modules/enhanced-resolve": {
-      "version": "5.24.2",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.2.tgz",
-      "integrity": "sha512-rpsZEGT1jFuve6QlpyRp9ckQ+kN61hvF9BzCPyMdaKTm8UJce96KBn3sorXOFXlzjPrs3Vc4T1NsSroZ3PxlFw==",
+      "version": "5.24.3",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.3.tgz",
+      "integrity": "sha512-PwKooW9JUzh5chmYfHM3IQl5OkK2u2Nm011MgeZrss3JmFraUx/fqrf78kk8GUMYoibx/14MdwTl/1WKkG7TpQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -9129,9 +9116,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.24.0.tgz",
-      "integrity": "sha512-YT6mBD8lGKkg4nM39enlm94/sfJIiW0YKUT60fBy4YK8tai31ylg1VhGNWxkpSKHo9UagfnZqwIff3HTDQwXeA==",
+      "version": "1.25.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.25.0.tgz",
+      "integrity": "sha512-/mdJTRbiwcLOQ1NZZK1amZF9rIZyvO18D6r9TngE6TG1NmqHgFuT4eE7Xrkm9UsXMbBJD1NlfwHVltCDWHrOTw==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9255,16 +9242,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "4.20260710.0",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260710.0.tgz",
-      "integrity": "sha512-x1LLRkU6o1p7hiKrB0TRnL0MJn6xFOT+/vrlEQINz5cRDKLP8ru4hBqWTIvXAetzr1acKAnmAaG84pQ4W/K14g==",
+      "version": "4.20260714.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260714.0.tgz",
+      "integrity": "sha512-MYlTCLdWCPqvrYY2uLwOjXwmglXuiHE3TGGkbOW4BwjUPa1r07E0iuHwrNDIs/sxK21r+o90Jx58AV2KeNdJZw==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.34.5",
         "undici": "7.28.0",
-        "workerd": "1.20260710.1",
+        "workerd": "1.20260714.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -10941,9 +10928,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.19",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.19.tgz",
-      "integrity": "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "funding": [
         {
           "type": "opencollective",
@@ -10960,7 +10947,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -12756,9 +12743,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260710.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260710.1.tgz",
-      "integrity": "sha512-U2sBPPrb9U97sBKnnMN6Kv8p65903P35nwMkPE9vSH/bRuRqkZ3a1EjUw3jV28RhiyXpkLF77Evzw8XimFxyTw==",
+      "version": "1.20260714.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260714.1.tgz",
+      "integrity": "sha512-oIbQzfdyl9UQUnG6XLegcSq0Mgt/7WKDbFOoqGgOWCS+/fhyGB460uKEgdAQQ9RHCO/ttcNCX/KiMIQzdoeu3Q==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -12769,17 +12756,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260710.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260710.1",
-        "@cloudflare/workerd-linux-64": "1.20260710.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260710.1",
-        "@cloudflare/workerd-windows-64": "1.20260710.1"
+        "@cloudflare/workerd-darwin-64": "1.20260714.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260714.1",
+        "@cloudflare/workerd-linux-64": "1.20260714.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260714.1",
+        "@cloudflare/workerd-windows-64": "1.20260714.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.111.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.111.0.tgz",
-      "integrity": "sha512-bffpI9EyrnpKkF/1S+RaIv8oRD93GtbsA7TlfWwOsGJGB7VO3jVbdGzpC9TU7Bqom3z7jUxcte4Z9MPhaQ4HoQ==",
+      "version": "4.112.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.112.0.tgz",
+      "integrity": "sha512-5H+XUD0TySCv1LuktFHDIEOkboH2nTfQs+35L+USt3MtntjDTMVIJprLgQcL2WBjulOyjxpd1vyTiSTJVW5MjQ==",
       "license": "MIT OR Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -12787,10 +12774,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "4.20260710.0",
+        "miniflare": "4.20260714.0",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260710.1"
+        "workerd": "1.20260714.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -12804,7 +12791,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260710.1"
+        "@cloudflare/workers-types": "^5.20260714.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package.json
+++ b/package.json
@@ -21,12 +21,12 @@
   "dependencies": {
     "@hcaptcha/react-hcaptcha": "^2.0.2",
     "@opennextjs/cloudflare": "^1.20.1",
-    "@radix-ui/react-avatar": "^1.2.2",
-    "@radix-ui/react-dialog": "^1.1.19",
+    "@radix-ui/react-avatar": "^1.2.3",
+    "@radix-ui/react-dialog": "^1.1.20",
     "@radix-ui/react-icons": "^1.3.2",
-    "@radix-ui/react-label": "^2.1.11",
+    "@radix-ui/react-label": "^2.1.12",
     "@radix-ui/react-slot": "^1.3.0",
-    "@radix-ui/react-switch": "^1.3.3",
+    "@radix-ui/react-switch": "^1.3.4",
     "@tabler/icons-react": "^3.45.0",
     "@tailwindcss/typography": "^0.5.20",
     "@vercel/analytics": "^2.0.1",
@@ -34,7 +34,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.24.0",
+    "lucide-react": "^1.25.0",
     "next": "^16.2.10",
     "next-auth": "^5.0.0-beta.31",
     "postgres": "^3.4.9",
@@ -59,7 +59,7 @@
     "eslint": "^10.7.0",
     "eslint-config-next": "^16.2.10",
     "eslint-plugin-drizzle": "^0.2.3",
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "prettier": "^3.9.5",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwindcss": "^4.3.3",
@@ -73,7 +73,7 @@
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1",
     "eslint-visitor-keys": "3.4.3",
-    "postcss": "^8.5.19",
+    "postcss": "^8.5.20",
     "ws": "^8.21.0"
   }
 }


### PR DESCRIPTION
## Summary

Update all dependencies to their latest compatible versions and regenerate `package-lock.json`.

### Updated packages

| Package | From | To |
|---------|------|----|
| `@radix-ui/react-avatar` | ^1.2.2 | ^1.2.3 |
| `@radix-ui/react-dialog` | ^1.1.19 | ^1.1.20 |
| `@radix-ui/react-label` | ^2.1.11 | ^2.1.12 |
| `@radix-ui/react-switch` | ^1.3.3 | ^1.3.4 |
| `lucide-react` | ^1.24.0 | ^1.25.0 |
| `postcss` | ^8.5.19 | ^8.5.20 |

### Notes

- **TypeScript 7 skipped**: `@typescript-eslint/parser@8.64.0` requires TypeScript `>=4.8.4 <6.1.0`, so TypeScript stays at ^6.0.3 until typescript-eslint adds v7 support.
- **postcss override** also updated to ^8.5.20 to match.
- **package-lock.json** fully regenerated from a clean install.
- Type-check (`tsc --noEmit`) passes with no errors.
- 0 npm audit vulnerabilities.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RWsaCnY4xhf2rvwfmPT7Un)_