### PR TITLE
fix(dashboard): create team members via admin API, not public signup

### DIFF
--- a/src/app/api/dashboard/team/route.ts
+++ b/src/app/api/dashboard/team/route.ts
@@ -72,7 +72,7 @@ export async function GET() {
   }
 }
 
-/** POST — create a new team member via /api/signup, then set custom claims. */
+/** POST — create a new team member via the admin API, then set custom claims. */
 export async function POST(req: NextRequest) {
   if (!(await checkAuth()))
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
@@ -107,22 +107,34 @@ export async function POST(req: NextRequest) {
         { status: 400 },
       );
 
-    // 1) Create the user account.
-    const signupRes = await pocketIdFetch("/api/signup", {
+    // 1) Create the user account via the admin endpoint. `/api/signup` is the
+    //    public self-registration route and is rejected with "Open user signup
+    //    is not enabled" when that toggle is off — admins create accounts
+    //    through `/api/users` (authenticated with the API key) instead. The
+    //    body mirrors the update route's shape; group membership is assigned
+    //    separately below.
+    const createRes = await pocketIdFetch("/api/users", {
       method: "POST",
       body: JSON.stringify({
         username,
         email,
         emailVerified: true,
         displayName: username,
-        userGroupIds: [groupId],
         disabled: false,
         isAdmin: false,
       }),
     });
-    const created = (await signupRes.json()) as PocketUser;
+    const created = (await createRes.json()) as PocketUser;
 
-    // 2) Set the Discord / Minecraft custom claims on the new user.
+    // 2) Assign the chosen OTP group (same endpoint the update route uses).
+    if (created?.id) {
+      await pocketIdFetch(`/api/users/${created.id}/user-groups`, {
+        method: "PUT",
+        body: JSON.stringify({ userGroupIds: [groupId] }),
+      });
+    }
+
+    // 3) Set the Discord / Minecraft custom claims on the new user.
     const claims = [
       { key: "Discord-id", value: discordId },
       { key: "Minecraft-uuid", value: minecraftUuid },


### PR DESCRIPTION
## Problem

Creating a team member from the dashboard failed with:

```json
{"error":"Open user signup is not enabled"}
```

The create handler (`POST /api/dashboard/team`) called PocketID's **public self-registration** endpoint `POST /api/signup`. That endpoint is gated by the server-side "Open user signup" toggle, which is intentionally **off** on the OTP instance — admins create accounts manually. So every create was rejected.

## Fix

Create the account through the **admin** endpoint `POST /api/users` instead. This is authenticated with the `X-API-KEY` admin key and is not gated by the signup toggle. The group is then assigned via `PUT /api/users/:id/user-groups`.

This mirrors exactly what the existing **update** route (`PUT /api/dashboard/team/[id]`) already does — same user-field body shape and same `/user-groups` endpoint for membership — so the create and update paths are now consistent.

## Changes

- `src/app/api/dashboard/team/route.ts`: `POST /api/signup` → `POST /api/users`; move group assignment to a separate `PUT /api/users/:id/user-groups` call (the admin endpoint no longer takes `userGroupIds` inline). Custom-claims handling is unchanged.

## Testing notes

- Type-safe: reuses the already-typed `pocketIdFetch` / `PocketUser` helpers, no new types.
- Full local `tsc`/build not runnable in this environment (dependencies not installed), but the change is limited to endpoint paths and payload shaping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_017aYy3e7ssz7tjKVyVWaPSH)_