### PR TITLE
feat(team): source public team page from PocketID, not the CMS

### DIFF
--- a/src/components/page/team.tsx
+++ b/src/components/page/team.tsx
@@ -2,47 +2,26 @@ import React from "react";
 import Image from "next/image";
 import Link from "next/link";
 import { getServerTranslations } from "@/lib/i18n/server";
+import { getPublicTeamMembers, type PublicTeamMember } from "@/lib/pocketid";
 import Reveal from "@/components/gsap/Reveal";
 
-interface Rank {
-  uuid: string;
-  Name: string;
-  Color: string;
-  Discord_role_id: string;
-  Priority: number;
-}
-
-interface TeamMember {
-  minecraft_username: string;
-  Name: string;
-  Ranks?: Rank;
-}
-
-async function getTeamMembers(): Promise<TeamMember[]> {
+async function getTeamMembers(): Promise<PublicTeamMember[]> {
   try {
-    const response = await fetch(
-      "https://cms.onthepixel.net/items/Team?fields=*.*.*",
-      { next: { revalidate: 300 } }
-    );
-    if (!response.ok) return [];
-    const data = await response.json();
-    return data.data || [];
+    // Sourced from the PocketID team system (the dashboard), not the legacy
+    // Directus CMS. Degrades to an empty list if PocketID is unreachable.
+    return await getPublicTeamMembers();
   } catch {
     return [];
   }
 }
 
 export default async function Team() {
-  const [teamMembers, { t }] = await Promise.all([
+  // `getPublicTeamMembers` already orders members by group weight (highest
+  // first), so no further sorting is needed here.
+  const [sortedMembers, { t }] = await Promise.all([
     getTeamMembers(),
     getServerTranslations(),
   ]);
-
-  const sortedMembers = [...teamMembers].sort((a, b) => {
-    const priorityA = a.Ranks ? a.Ranks.Priority : 999;
-    const priorityB = b.Ranks ? b.Ranks.Priority : 999;
-    return priorityA - priorityB;
-  });
 
   return (
     <section className="py-10 px-4 bg-gray-950">
@@ -60,18 +39,18 @@ export default async function Team() {
             distance={30}
             className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3"
           >
-            {sortedMembers.map((member, index) => {
-              const mainRank = member.Ranks;
+            {sortedMembers.map((member) => {
+              const avatarId = member.minecraftUuid || member.username;
 
               return (
                 <div
-                  key={index}
+                  key={member.id}
                   className="m-1 flex items-center rounded-md bg-white/10 p-4 transition-transform duration-300 hover:scale-105 hover:bg-white/15 gap-4"
                 >
                   <div className="relative shrink-0 rounded-lg overflow-hidden">
                     <Image
-                      alt={member.minecraft_username}
-                      src={`https://api.mcskin.me/pfp/${member.minecraft_username}`}
+                      alt={member.name}
+                      src={`https://api.mcskin.me/pfp/${avatarId}`}
                       width={64}
                       height={64}
                       className="rounded-lg object-cover"
@@ -79,13 +58,13 @@ export default async function Team() {
                   </div>
 
                   <div className="min-w-0">
-                    <p className="font-bold text-white truncate">{member.Name}</p>
-                    {mainRank ? (
+                    <p className="font-bold text-white truncate">{member.name}</p>
+                    {member.rankName ? (
                       <p
                         className="text-sm font-semibold tracking-wide truncate"
-                        style={{ color: mainRank.Color }}
+                        style={{ color: member.rankColor }}
                       >
-                        {mainRank.Name.toUpperCase()}
+                        {member.rankName.toUpperCase()}
                       </p>
                     ) : (
                       <p className="text-sm text-gray-400">{t.team.memberFallback}</p>

--- a/src/lib/pocketid.ts
+++ b/src/lib/pocketid.ts
@@ -70,9 +70,20 @@ export class PocketIdError extends Error {
   }
 }
 
+/** Optional caching behaviour for a PocketID request. */
+export interface PocketIdFetchOpts {
+  /**
+   * When set, the request participates in Next.js data caching with this
+   * revalidation window (seconds) instead of the default `no-store`. Use for
+   * public, read-only calls that don't need per-request freshness.
+   */
+  revalidate?: number;
+}
+
 export async function pocketIdFetch(
   path: string,
   init: RequestInit = {},
+  opts: PocketIdFetchOpts = {},
 ): Promise<Response> {
   const apiKey = getApiKey();
   if (!apiKey) {
@@ -90,10 +101,15 @@ export async function pocketIdFetch(
     headers.set("Content-Type", "application/json");
   }
 
+  const cacheInit: RequestInit =
+    opts.revalidate != null
+      ? { next: { revalidate: opts.revalidate } }
+      : { cache: "no-store" };
+
   const res = await fetch(`${POCKETID_BASE}${path}`, {
     ...init,
+    ...cacheInit,
     headers,
-    cache: "no-store",
   });
 
   if (!res.ok) {
@@ -109,7 +125,10 @@ export async function pocketIdFetch(
 }
 
 /** Fetch every page of a paginated PocketID collection endpoint. */
-export async function fetchAllPages<T>(path: string): Promise<T[]> {
+export async function fetchAllPages<T>(
+  path: string,
+  opts: PocketIdFetchOpts = {},
+): Promise<T[]> {
   const items: T[] = [];
   let page = 1;
   let totalPages: number;
@@ -118,6 +137,8 @@ export async function fetchAllPages<T>(path: string): Promise<T[]> {
   do {
     const res = await pocketIdFetch(
       `${path}${sep}pagination[page]=${page}&pagination[limit]=100`,
+      {},
+      opts,
     );
     const json = (await res.json()) as Paginated<T>;
     items.push(...(json.data ?? []));
@@ -178,4 +199,113 @@ export function slugifyGroupName(input: string): string {
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");
   return slug || "group";
+}
+
+/* -------------------------------------------------------------------------- */
+/*  Public team listing                                                       */
+/* -------------------------------------------------------------------------- */
+
+/** Numeric `weight` claim of a group (0 when unset/invalid). */
+export function groupWeight(group: UserGroup | undefined): number {
+  const raw = readClaim(group?.customClaims, "weight");
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) ? n : 0;
+}
+
+/** Legacy Minecraft colour codes → hex. */
+const MC_COLORS: Record<string, string> = {
+  "0": "#000000",
+  "1": "#0000AA",
+  "2": "#00AA00",
+  "3": "#00AAAA",
+  "4": "#AA0000",
+  "5": "#AA00AA",
+  "6": "#FFAA00",
+  "7": "#AAAAAA",
+  "8": "#555555",
+  "9": "#5555FF",
+  a: "#55FF55",
+  b: "#55FFFF",
+  c: "#FF5555",
+  d: "#FF55FF",
+  e: "#FFFF55",
+  f: "#FFFFFF",
+};
+
+/** Fallback rank colour when a prefix carries no usable colour information. */
+const DEFAULT_RANK_COLOR = "#AAAAAA";
+
+/**
+ * Derive a display colour from a Minecraft-style group prefix. Supports hex
+ * codes (`&#RRGGBB`) and legacy colour codes (`&c`, `§a`, …); falls back to a
+ * neutral grey when no colour is present.
+ */
+export function prefixColor(prefix: string | undefined): string {
+  if (!prefix) return DEFAULT_RANK_COLOR;
+  const hex = prefix.match(/[&§]?#([0-9a-fA-F]{6})/);
+  if (hex) return `#${hex[1]}`;
+  const code = prefix.match(/[&§]([0-9a-fA-F])/);
+  if (code) return MC_COLORS[code[1].toLowerCase()] ?? DEFAULT_RANK_COLOR;
+  return DEFAULT_RANK_COLOR;
+}
+
+/** A team member shaped for the public `/team` page. Carries no email/PII. */
+export interface PublicTeamMember {
+  /** PocketID user id (stable React key). */
+  id: string;
+  /** Display name, falling back to the username. */
+  name: string;
+  /** Login name — used for the skin avatar when no Minecraft UUID is set. */
+  username: string;
+  /** Minecraft UUID custom claim (preferred avatar lookup). */
+  minecraftUuid: string;
+  /** Friendly name of the member's highest-weight OTP group. */
+  rankName: string;
+  /** Colour derived from that group's prefix. */
+  rankColor: string;
+  /** Weight of that group (used for ordering, highest first). */
+  weight: number;
+}
+
+/**
+ * Fetch the OTP team members for the public `/team` page from PocketID.
+ *
+ * Replaces the legacy Directus CMS `Team` collection. Only enabled accounts in
+ * an OTP-team group are returned, ranked by their group's weight (highest
+ * first), and no email/PII leaves the server. Results are cached for 5 minutes.
+ */
+export async function getPublicTeamMembers(): Promise<PublicTeamMember[]> {
+  const [groups, users] = await Promise.all([
+    fetchAllPages<UserGroup>("/api/user-groups", { revalidate: 300 }),
+    fetchAllPages<PocketUser>("/api/users", { revalidate: 300 }),
+  ]);
+
+  const otpIds = otpGroupIds(groups);
+  const groupById = new Map(groups.map((g) => [g.id, g]));
+
+  return users
+    .filter((u) => !u.disabled && isOtpMember(u, otpIds))
+    .map((u) => {
+      // Resolve the user's OTP groups to their full definitions (the group
+      // objects embedded on the user may omit custom claims / friendly names).
+      const memberGroups = (u.userGroups ?? [])
+        .filter((g) => otpIds.has(g.id))
+        .map((g) => groupById.get(g.id) ?? g);
+
+      // Highest weight wins as the member's primary rank.
+      const primary = memberGroups
+        .slice()
+        .sort((a, b) => groupWeight(b) - groupWeight(a))[0];
+
+      return {
+        id: u.id,
+        name: u.displayName ?? u.username,
+        username: u.username,
+        minecraftUuid: getClaim(u, "Minecraft-uuid"),
+        rankName: primary?.friendlyName ?? primary?.name ?? "",
+        rankColor: prefixColor(readClaim(primary?.customClaims, "prefix")),
+        weight: groupWeight(primary),
+      } satisfies PublicTeamMember;
+    })
+    .sort((a, b) => b.weight - a.weight);
 }


### PR DESCRIPTION
## What & why

The public `/team` page still pulled its members from the legacy Directus CMS (`https://cms.onthepixel.net/items/Team`), even though team members are now managed entirely through the new PocketID-based team system (the dashboard at `/dashboard/team`). This makes the public page read from that same source, so there's a single place to manage the team.

## Changes

- **`src/lib/pocketid.ts`**
  - `getPublicTeamMembers()` — fetches OTP team members from PocketID for the public page. Returns only **enabled** accounts that belong to an OTP-team group, ordered by their group's `weight` (highest first), and carries **no email/PII**.
  - Rank name comes from the member's highest-weight OTP group (`friendlyName`); rank colour is derived from that group's Minecraft-style `prefix` (`prefixColor()` supports both `&#RRGGBB` hex and legacy `&c` / `§a` colour codes, with a neutral-grey fallback).
  - `pocketIdFetch` / `fetchAllPages` gained an optional `revalidate` cache window; the public listing uses 5 minutes (matching the old CMS `revalidate: 300`). Existing authenticated callers are unchanged and still use `no-store`.
- **`src/components/page/team.tsx`**
  - Rewired to `getPublicTeamMembers()` instead of the CMS fetch. Avatar lookup prefers the Minecraft UUID and falls back to the username. Degrades to an empty list if PocketID is unreachable (same graceful behaviour as before).

## Notes / trade-offs

- Group **weight** is treated as descending priority (higher weight = higher rank), replacing the CMS `Priority` (which sorted ascending).
- The old CMS `Team` collection had an explicit per-rank colour; PocketID groups don't, so colour is inferred from the prefix's colour code. If a prefix has no colour code, ranks render in neutral grey.
- The public page relies on the `pocketid-apikey` env var already used by the dashboard; without it the list falls back to empty rather than erroring.

## Verification

- `tsc --noEmit` passes.
- `next lint` is currently broken in this Next version (unrelated to this change); ESLint can't run standalone due to the repo's legacy config format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L1nefQVTSs5taDcizm6Pfs

---
_Generated by [Claude Code](https://claude.ai/code/session_01L1nefQVTSs5taDcizm6Pfs)_