### PR TITLE
Update dependencies to latest compatible versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "gsap": "^3.15.0",
-        "lucide-react": "^1.28.0",
+        "lucide-react": "^1.29.0",
         "next": "^16.3.0",
         "next-auth": "^5.0.0-beta.32",
         "postgres": "^3.4.9",
@@ -41,18 +41,18 @@
         "@types/node": "^26.1.2",
         "@types/react": "^19.2.18",
         "@types/react-dom": "^19.2.4",
-        "@typescript-eslint/eslint-plugin": "^8.65.0",
-        "@typescript-eslint/parser": "^8.65.0",
+        "@typescript-eslint/eslint-plugin": "^8.66.0",
+        "@typescript-eslint/parser": "^8.66.0",
         "autoprefixer": "^10.5.4",
         "drizzle-kit": "^0.31.10",
         "eslint": "^10.8.0",
         "eslint-config-next": "^16.3.0",
         "eslint-plugin-drizzle": "^0.2.3",
-        "postcss": "^8.5.25",
+        "postcss": "^8.5.26",
         "prettier": "^3.9.6",
         "prettier-plugin-tailwindcss": "^0.8.1",
         "tailwindcss": "^4.3.3",
-        "tsx": "^4.23.9",
+        "tsx": "^4.23.10",
         "typescript": "^6.0.3"
       }
     },
@@ -9139,9 +9139,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.28.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.28.0.tgz",
-      "integrity": "sha512-fARAFJULsGuDDydjp6+6blekG/sBIM29TerzLjc9bQUKAcEfrSc4ZQKb25KRz4OMKd87cZTb5dgq0w/T6KufVg==",
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.29.0.tgz",
+      "integrity": "sha512-Xs9QFG5+9sNX04MdKVT4++umA+hJ2qsJVlRlRWHQ7qZobXgMiNHSpZ5eZm8JUoGCdNyoEdXoEwa8HVr0DNjOQg==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -10489,9 +10489,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.25",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
-      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
+      "version": "8.5.26",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+      "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
       "funding": [
         {
           "type": "opencollective",
@@ -10508,7 +10508,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.16",
+        "nanoid": "^3.3.17",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -11789,9 +11789,9 @@
       "license": "0BSD"
     },
     "node_modules/tsx": {
-      "version": "4.23.9",
-      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.9.tgz",
-      "integrity": "sha512-6q8uTORRGauQVjqMQnKUucLFoeXZAfw6zKvG35GLbdKWbLdeOtZ3H4mhyA5mxuUd2o2cRTskhj59nLLQseUvUw==",
+      "version": "4.23.10",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.10.tgz",
+      "integrity": "sha512-0Vb9eKU47njkxv/6B8CRZRDsxNDT/Pz+BIU+M5jw7xL3TdzAjSxlZUxu0xFL/kLpaG3sHZ0LH2wbK1T1yo7CUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.28.0",
+    "lucide-react": "^1.29.0",
     "next": "^16.3.0",
     "next-auth": "^5.0.0-beta.32",
     "postgres": "^3.4.9",
@@ -52,18 +52,18 @@
     "@types/node": "^26.1.2",
     "@types/react": "^19.2.18",
     "@types/react-dom": "^19.2.4",
-    "@typescript-eslint/eslint-plugin": "^8.65.0",
-    "@typescript-eslint/parser": "^8.65.0",
+    "@typescript-eslint/eslint-plugin": "^8.66.0",
+    "@typescript-eslint/parser": "^8.66.0",
     "autoprefixer": "^10.5.4",
     "drizzle-kit": "^0.31.10",
     "eslint": "^10.8.0",
     "eslint-config-next": "^16.3.0",
     "eslint-plugin-drizzle": "^0.2.3",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "prettier": "^3.9.6",
     "prettier-plugin-tailwindcss": "^0.8.1",
     "tailwindcss": "^4.3.3",
-    "tsx": "^4.23.9",
+    "tsx": "^4.23.10",
     "typescript": "^6.0.3"
   },
   "overrides": {
@@ -73,7 +73,7 @@
     "yargs": "17.7.2",
     "yargs-parser": "21.1.1",
     "eslint-visitor-keys": "3.4.3",
-    "postcss": "^8.5.25",
+    "postcss": "^8.5.26",
     "ws": "^8.21.1"
   }
 }


### PR DESCRIPTION
## Summary

- **lucide-react**: `^1.28.0` → `^1.29.0` (minor)
- **@typescript-eslint/eslint-plugin**: `^8.65.0` → `^8.66.0` (minor)
- **@typescript-eslint/parser**: `^8.65.0` → `^8.66.0` (minor)
- **postcss**: `^8.5.25` → `^8.5.26` (patch, including overrides sync)
- **tsx**: `^4.23.9` → `^4.23.10` (patch)

`package-lock.json` has been regenerated to reflect all updated versions.

### Skipped

- **typescript**: `^6.0.3` → `^7.0.2` — skipped because `@typescript-eslint/eslint-plugin` and `@typescript-eslint/parser` require `typescript <6.1.0` as a peer dependency. This major bump can be revisited once `@typescript-eslint` releases a compatible version.

### Verification

- `tsc --noEmit` passes with no errors
- `npm install` completes successfully

---
_Generated by [Claude Code](https://claude.ai/code/session_01UDEXuwh3PLJp372cufQ5z5)_