### PR TITLE
chore(deps): refresh lock file with latest sub-dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -365,13 +365,13 @@
       }
     },
     "node_modules/@aws-sdk/checksums": {
-      "version": "3.1000.27",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.27.tgz",
-      "integrity": "sha512-insWOqKKNUrbN/dohEG7BJ0U5GkyqhjbMb/NHNaLUtq+7my2M8C4EnZZZoxMmXRqCC+P9dEr+KyJA2JGGzoKLg==",
+      "version": "3.1000.28",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.28.tgz",
+      "integrity": "sha512-VCpnmyHQ1IH49ni3LXnQj7DPr7rmcJmzYeiCkYdCcfgNtkvOj38cdcL9lapBWoItZWFACJPFJlymqC7/gem3Gw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -659,13 +659,13 @@
       }
     },
     "node_modules/@aws-sdk/core": {
-      "version": "3.977.7",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.7.tgz",
-      "integrity": "sha512-I88Iov89NVmjSmJLKSv7Cn9M2J+a2942OkA8nZCbz+sl4ZeY4zEOcoLOrbt1GRfQ8zEQKnjAJdXixA3J/p1fDQ==",
+      "version": "3.977.8",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.8.tgz",
+      "integrity": "sha512-7+Kcrkvrk9lM/m7jRhHpT4jCdvzGHsuaSRbF8TdzzkY1mRzp/Ogwf9c7H29k4gGhey0BBWhCWr16+t0J61gwmg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
-        "@aws-sdk/xml-builder": "^3.972.38",
+        "@aws-sdk/types": "^3.974.4",
+        "@aws-sdk/xml-builder": "^3.972.39",
         "@aws/lambda-invoke-store": "^0.3.0",
         "@smithy/core": "^3.31.1",
         "@smithy/signature-v4": "^5.6.12",
@@ -678,13 +678,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-env": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.68.tgz",
-      "integrity": "sha512-2a20A/IdNOwUvaDq91iqqS7BA0XlNMfW3iLGZGZLJv0EbUqhSxB0PIx4rQQqssvWj1uXImb3/UCCdHz/+1dOiA==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.69.tgz",
+      "integrity": "sha512-AreCFzcB4kH2HF9031Ot0jSJr3KXvRg6e8uDeub20JEVdZU3Bv0sTq1plc7VsT3KiqutlzH7l0j50UcCWHUioA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -694,13 +694,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-http": {
-      "version": "3.972.70",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.70.tgz",
-      "integrity": "sha512-0yRem2Fs52r/Nn6UAqIlpjexfaYj8ziEozOe9tamtAVT/5bzFLKx8O2r7MaRqgS3hGKHIa1Jij9nKHSsNnb04A==",
+      "version": "3.972.71",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.71.tgz",
+      "integrity": "sha512-A8ObcqVmDMnk4F9NozZ7JwmUu9Q4xyBJkmyq1C5U+wNM9ht9J7+EuuyabsLWXZnOoTqFaJuYBYTKf5CTipkEjA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -712,20 +712,20 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-ini": {
-      "version": "3.973.13",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.13.tgz",
-      "integrity": "sha512-2M39DE02XpYYaSWYk/4AsImXYUU/1L2xmTMLUpMMWq7DfLv191/vCRy3baKtdr45AkJQyVgSjmuVOLm15SwrRQ==",
+      "version": "3.973.14",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.14.tgz",
+      "integrity": "sha512-7c+Wti2LsERNWMfm7ySz3/6RPopFW3Nmn7s63Xpcq6R/tRuY5hpvkHA2xVgi5ukJbvok9l0IDtVEvqTtg+X7dw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-login": "^3.972.75",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-login": "^3.972.76",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -736,14 +736,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-login": {
-      "version": "3.972.75",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.75.tgz",
-      "integrity": "sha512-jaTESuJlQsoUZ44f/i2puyPt8VlF/dMMJ9HM3cStYtk7eKX4N9UWi83OLixUkoOJH3BwWlPLCq9YIK9nfWhVBg==",
+      "version": "3.972.76",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.76.tgz",
+      "integrity": "sha512-LVixwOnEJfrrfKHeZjBA8pIMTZjNDq8ak8VpcoWUuCJDrSnBNU8POJksULMgvN089P0MXtQYH2Zs627/MK1K0g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -753,18 +753,18 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-node": {
-      "version": "3.972.79",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.79.tgz",
-      "integrity": "sha512-RIw5dof1EHkWubrZzPC941CDtnFG1iAXsxbFgLkhdYZXHc4icU13c/uxSMI0J5eUx9bxa7LjfpdjfClBB1QsDA==",
+      "version": "3.972.80",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.80.tgz",
+      "integrity": "sha512-bE2qh8ww4iClO1jHsBXdOE8FUgzDbdxbyorNjSCoPSkQd51k3jODItuPZfuwcLHZqDXsH+bI4AMHhqtuyR7mSg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/credential-provider-env": "^3.972.68",
-        "@aws-sdk/credential-provider-http": "^3.972.70",
-        "@aws-sdk/credential-provider-ini": "^3.973.13",
-        "@aws-sdk/credential-provider-process": "^3.972.68",
-        "@aws-sdk/credential-provider-sso": "^3.973.12",
-        "@aws-sdk/credential-provider-web-identity": "^3.972.74",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/credential-provider-env": "^3.972.69",
+        "@aws-sdk/credential-provider-http": "^3.972.71",
+        "@aws-sdk/credential-provider-ini": "^3.973.14",
+        "@aws-sdk/credential-provider-process": "^3.972.69",
+        "@aws-sdk/credential-provider-sso": "^3.973.13",
+        "@aws-sdk/credential-provider-web-identity": "^3.972.75",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/credential-provider-imds": "^4.4.16",
         "@smithy/types": "^4.16.1",
@@ -775,13 +775,13 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-process": {
-      "version": "3.972.68",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.68.tgz",
-      "integrity": "sha512-nLP3Pda2MQTFJ25hKBMmUuB9Uv+bTZQNlufbeCwklP549Vwnkd8bRLJoCKp5k6xjmdyptrPrOfGOhN0mKuca8A==",
+      "version": "3.972.69",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.69.tgz",
+      "integrity": "sha512-9kpTNdZTrcqXTfhxM7fgl9Z68ek3Fu5oe3Yf+A/pJGibEqpgZxz2tSY7SinmyCIU2PJ+ygY4FPoBBnLpocMtrQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -791,15 +791,15 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-sso": {
-      "version": "3.973.12",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.12.tgz",
-      "integrity": "sha512-EmgyyHn+f9WCcelp3L/vci+LGbX8GigWaVphRArjVo5Pktkr9YnLy/mQ6VDkDyBD72dtfRNTgHmD2ts4rTDXKQ==",
+      "version": "3.973.13",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.13.tgz",
+      "integrity": "sha512-Oc81qauMPzUoTnAS2YKpNwY6sY/LUyQTEeaf6yP197WMxkEBQfcKLR1MFpD7+pNTubXnfkH6gwpji+Gc7iyD2Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/token-providers": "3.1108.0",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/token-providers": "3.1111.0",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -809,14 +809,14 @@
       }
     },
     "node_modules/@aws-sdk/credential-provider-web-identity": {
-      "version": "3.972.74",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.74.tgz",
-      "integrity": "sha512-0YfczxGXF3RjGj8z7QG/Ho2HnLGKDHfPSHiTs47UU1U/+mmwISDN+rvGKt2zh+3FX8NdT4xd95LGBGyhQw2dgQ==",
+      "version": "3.972.75",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.75.tgz",
+      "integrity": "sha512-YPN6uoGDgjjjeVFZrcOeCJqmB6zpXoeeNgIjqe+DexJaWqdjVfCCe+VAZwli9Z2h8KhFW8oxkO39emQ1tyz/Mw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -826,12 +826,12 @@
       }
     },
     "node_modules/@aws-sdk/dynamodb-codec": {
-      "version": "3.973.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.42.tgz",
-      "integrity": "sha512-EJjm82YDsWjN991merbDHEprA1s8OYPRtPYaMD57MvilZeCJ4lMAld/gZGFpVN6d1dmYoh4DKTFlWJVfmfMhcg==",
+      "version": "3.973.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/dynamodb-codec/-/dynamodb-codec-3.973.43.tgz",
+      "integrity": "sha512-5nw01fhFJEKM68n0R65S1DijiSAQWZVbvH7IxTIJpFFbggg816jBVYvhK7W+XISjvtdg0rMkF/gQmuLGH713mg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -841,9 +841,9 @@
       }
     },
     "node_modules/@aws-sdk/endpoint-cache": {
-      "version": "3.972.10",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.10.tgz",
-      "integrity": "sha512-xL5sogJajtyGU8p/pA2e8P6dQqs0P6wj2FtBNcZ5VxyBovpoxghKi9hPEkjx+THZijgGW9fOP9EsHDcraSxF8A==",
+      "version": "3.972.11",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/endpoint-cache/-/endpoint-cache-3.972.11.tgz",
+      "integrity": "sha512-8q1ICxcDjHId3bBryuu/j+1L9y5/3uQnwzLDt5j2ElcjZSoWmFtymdJy7OjLrluSMe0Z4mq5bcH4fxBXvlEHfw==",
       "license": "Apache-2.0",
       "dependencies": {
         "mnemonist": "0.38.3",
@@ -854,12 +854,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-bucket-endpoint": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.46.tgz",
-      "integrity": "sha512-j3wb18SOUcRPVFi9g9jh2ughzNHMpGysRxrzfkAlmfSbayRdmYF80OKcND0GdP3dNgIdAo3w2yC/hjKkuuh8sg==",
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.47.tgz",
+      "integrity": "sha512-LBVcGmfD0ppJeSFrezTNII+6U1FoG2DtqDOweFfZF4W0Y68XerTkp7OkW2PS4CQPeGVtl31tc6Yy/x7f+GdzZg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.73",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -867,13 +867,13 @@
       }
     },
     "node_modules/@aws-sdk/middleware-endpoint-discovery": {
-      "version": "3.972.28",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.28.tgz",
-      "integrity": "sha512-T4F2dZRK80PyigacWVH2Garx6x3oH24tfOZxsv8zLqha+0K0zBS4GvbnFTgHTVjAdJGAYisxQHD/TNDJh+Up/w==",
+      "version": "3.972.29",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint-discovery/-/middleware-endpoint-discovery-3.972.29.tgz",
+      "integrity": "sha512-cXW7QNIOhUSfccZmwJEjn9EdCAjzdOtt/+MtO5HWgxIZdhzyC1kNuQKIgGEDkgabxiXymWw0/VFWdqxqeLbgMA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/endpoint-cache": "^3.972.10",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/endpoint-cache": "^3.972.11",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -883,12 +883,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-expect-continue": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.42.tgz",
-      "integrity": "sha512-X5yM4CxhsZ6lPQec0HdVIB1KpakkYUDpFf9zf3Bas+WGvSn6aLeJIZMGW7XWDF+NhEDf56I3JfOniP2trd1OuA==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.43.tgz",
+      "integrity": "sha512-AghIJeHCYdofFmEzg0gCbMtfB+g9VFNfy7EWV9f+lI59g4p9FpAd1fAjPj39K2LXzHn+J0U/9Qa4RwrauCDe1w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.73",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -896,12 +896,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-flexible-checksums": {
-      "version": "3.974.52",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.52.tgz",
-      "integrity": "sha512-t5pgz++cTDJU8kpSdX+qOlsqAtrCfZ1P72p8DwPOPc23Q3KC9Ea3pYMfJKtIkiwfSkj3q0aNcAkpCvikkIssUg==",
+      "version": "3.974.53",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.53.tgz",
+      "integrity": "sha512-FceyVwv0ZezUwOzA7BSggQHll1hkjlxabRUx1Owtikqixl6anYKqfu1P+DmjJIMAWHhyw4wPb3Olndi814kgLA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/checksums": "^3.1000.27",
+        "@aws-sdk/checksums": "^3.1000.28",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -909,12 +909,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-host-header": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.43.tgz",
-      "integrity": "sha512-K9cJfuhjywrlWuaW0HZ/724pgc5AVKfRY/2yZeuE0g2EQyL4kxTT7uZBTiy4KJkWs0DYYZ5aEEHTLAD0obTEBQ==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.972.44.tgz",
+      "integrity": "sha512-rOHfp3sV/NOcwbkdGTh6cDG1C16dBSZEZuqhuaTqe5FutryQkr+4atE3vYryV/3q3Z0gw+h0iMkVnABu5pWjLg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -922,12 +922,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-location-constraint": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.39.tgz",
-      "integrity": "sha512-lX9N7mr9hDd7GrdeWDhWshhFZUGvFG9WPsBe/wM20IOa4QmuhoOVvbLMQg4j063REO7Npif9fvqAH9pemNtSbA==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.40.tgz",
+      "integrity": "sha512-+6dx8UJdVg6oWC7hWrebDr6qXlmDRRIV5jDo1Piu+Hyp1xXhLR8DCjX8cho6FCqvAS27vCZj7onLxNFLMvwEFw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.73",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -935,12 +935,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-logger": {
-      "version": "3.972.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.42.tgz",
-      "integrity": "sha512-rpMHkaiwLMLzxtdcpgYqEi/E6n9NKYB1YGnyxgaKOg6eYl3ecHcwU3w5SXlBU7OPPSMNXlhmG154qIoS6Jkiwg==",
+      "version": "3.972.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.972.43.tgz",
+      "integrity": "sha512-FilmoydCynG2nXWHhbW3/SrumxfcW98qi+9E5Eg3PDMRbOTHbsTzECGUZZZ9YTafFO8MPmYjb3OXbR4M69zYnQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -948,12 +948,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-recursion-detection": {
-      "version": "3.972.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.44.tgz",
-      "integrity": "sha512-p0MNv7N9NrybvMibtSyGmk9DI8QoRpOyAw3NBInV2gk2WJdfFNtLyYx08xshdQHQmA6kJlSsao0Z39uzo4CRBQ==",
+      "version": "3.972.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.972.45.tgz",
+      "integrity": "sha512-z674qMLpd8gwgcrXP4A//j4Af81NKJJpl88G4bWgKwwJebzDbjsEaNIm6qegXrSJaaiXGx7/G6kNlfCO0a//Ag==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -961,14 +961,14 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3": {
-      "version": "3.972.73",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.73.tgz",
-      "integrity": "sha512-oy7sRA5HvHcAvkcKX6F8RI240jcOf3c8y/Gqjs9qemIibdKQqGBIi0uwa+47ZRYqGLpdEO28TQU4G73yUzo06Q==",
+      "version": "3.972.74",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.74.tgz",
+      "integrity": "sha512-2lzoV2z2QO5KJZYGOCnIZ1WVQgzMECvwuzr1xb034a++8QW4U4eGrmC2u4yg1xvNv4TLL/Uv5DLyuAiw0b9z7Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -978,12 +978,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-s3/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
-      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -993,12 +993,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-sdk-sqs": {
-      "version": "3.972.40",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.40.tgz",
-      "integrity": "sha512-inMaGeVemJEIp9Bc5Wlw0aVgVgUr/OwGqg5CLwO8TbMi6m1xFd+BG0fO/nJKVS/rkb9FSRxU/l0njDBz8OQvHQ==",
+      "version": "3.972.41",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sqs/-/middleware-sdk-sqs-3.972.41.tgz",
+      "integrity": "sha512-07AbG/6LlaoC3YJ97vPgWVYFGWg3W3Bdr1ow3xjwti5u9/PjVD8+wB+qu2jDZnIvE6F7Y4ONWYCDQTPxiepdnA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1008,12 +1008,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-ssec": {
-      "version": "3.972.39",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.39.tgz",
-      "integrity": "sha512-zjJsW12PDHyl15vbDSZIolS3u6tubZ3kRIkzHanuZAjnutZaNVJrejfgGGCi7E4gQ7mQmUeE8IkYyPFgNjJlrw==",
+      "version": "3.972.40",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.40.tgz",
+      "integrity": "sha512-CgwKB63KeyEjMaBU5d+UxqQBWETxXigL0cnPJcBO2mkYdlC0rOj6QidmV68AT8i/0tTQqfrqQKTKBLqgBmygVw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/middleware-sdk-s3": "^3.972.73",
+        "@aws-sdk/middleware-sdk-s3": "^3.972.74",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1021,12 +1021,12 @@
       }
     },
     "node_modules/@aws-sdk/middleware-user-agent": {
-      "version": "3.972.72",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.72.tgz",
-      "integrity": "sha512-22iPFQNPVsn5Wlf9U41b5AhT1MWw+cw0v2QO7NnZyF0cyC/EDqNTBr1DbYSbfaq4AUwoNxKRwRxKYchBY9kvrw==",
+      "version": "3.972.73",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.972.73.tgz",
+      "integrity": "sha512-OmHHVZOLsmu4+XlmPW1Fo4D/MpFkC9YXe/ayQN/VVRZqEL7voHwI8a/8kKsJABRmOo/SJhMZR0guzrluCrthZQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1034,14 +1034,14 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients": {
-      "version": "3.997.42",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.42.tgz",
-      "integrity": "sha512-XWRyon2MTHXD/zMoo0Mbge6Vwf+iE0qQaM/RyGO6NfZ9WukCFiQL27nQVZjYy2JwSIg+iXZxKOX95OBXqlSM4w==",
+      "version": "3.997.43",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.43.tgz",
+      "integrity": "sha512-bit+VpqWNyi3wHxFoTsTliNXimCSL2r2OeDTm7ZrG+YsTZ2D7ofDJ6r/t9PVBn80i6/v0X2h9Tgw6QP2MAKfPw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/signature-v4-multi-region": "^3.996.44",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/signature-v4-multi-region": "^3.996.45",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/fetch-http-handler": "^5.6.13",
         "@smithy/node-http-handler": "^4.9.13",
@@ -1053,12 +1053,12 @@
       }
     },
     "node_modules/@aws-sdk/nested-clients/node_modules/@aws-sdk/signature-v4-multi-region": {
-      "version": "3.996.44",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.44.tgz",
-      "integrity": "sha512-ZSfQ35Qn4MhSY+A0Whyr+KBx+wJKZUyBsOrjB2pSHOafRzbFe47T8XcXM8hZqUAC69qnqIy0C9ArxTuud0CC2w==",
+      "version": "3.996.45",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.45.tgz",
+      "integrity": "sha512-bBuyztukzXq6plzFGHAWiQt0QXo+HL8b8lX5cFTzkez/74PtS1c0qPFCIVuHkyoT+miH2qOjAcm1/yoro2ESPA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/signature-v4": "^5.6.12",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1068,12 +1068,12 @@
       }
     },
     "node_modules/@aws-sdk/region-config-resolver": {
-      "version": "3.972.46",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.46.tgz",
-      "integrity": "sha512-PO2SO0AuCroZtqwhrcw8DB4nPqXK8d3/CYllap4bkWO9H/J8kc+OfYVFqDn7l3DZ9eSdGge3Dmk6ilINwW4Jgw==",
+      "version": "3.972.47",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.972.47.tgz",
+      "integrity": "sha512-W32DAq3caOpv56lDpETLJ4gMWUeHrTHBevHBq0qE4txs9cgIKI1EAjkYLVUJSYIciwz6t9ydszle0nZfsDDDkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1098,14 +1098,14 @@
       }
     },
     "node_modules/@aws-sdk/token-providers": {
-      "version": "3.1108.0",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1108.0.tgz",
-      "integrity": "sha512-rI80zxDxGJ6904eC/YbjkdjY6JdaZvQ01kOmrMvw7cFQGIHo27fhnIVbMSVDS4T6foQImjxYSRoOu/uSJscXDw==",
+      "version": "3.1111.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1111.0.tgz",
+      "integrity": "sha512-JfljgoVtl+s3Qy21n9a7Z48uCQaOXcN74KJ3TEQfPoB293GrXFSt6HSQJF1sTZ8c/5QedEvd3NjJQMO4u9qa5A==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
-        "@aws-sdk/nested-clients": "^3.997.42",
-        "@aws-sdk/types": "^3.974.3",
+        "@aws-sdk/core": "^3.977.8",
+        "@aws-sdk/nested-clients": "^3.997.43",
+        "@aws-sdk/types": "^3.974.4",
         "@smithy/core": "^3.31.1",
         "@smithy/types": "^4.16.1",
         "tslib": "^2.6.2"
@@ -1115,9 +1115,9 @@
       }
     },
     "node_modules/@aws-sdk/types": {
-      "version": "3.974.3",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.3.tgz",
-      "integrity": "sha512-ECAqfpNsef+7MO8qtR0h9KcFIBAygaE7Cm6UOiQl+ft+uVap+1G7bNEjs4mdJE2OnA4m6k7i8peH8uGIAsOMGw==",
+      "version": "3.974.4",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.4.tgz",
+      "integrity": "sha512-dSFDNG00MEz0/xl5gxL62giLd1iYyJsTxZ1I1DOj6lC+bbgLB4TRsYClJg3b62dhXT1uATzsTNXPnC+33EJV3A==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",
@@ -1144,9 +1144,9 @@
       }
     },
     "node_modules/@aws-sdk/util-locate-window": {
-      "version": "3.965.9",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.9.tgz",
-      "integrity": "sha512-wB/ho7pTJKqWz3WYDt2ZWDWI8bxQpN/xwf+5ZQ1zWaj+HDY9B8Fn434i6qZ6j6ZG3aCiIJtZaQVqwajx5xYsQA==",
+      "version": "3.965.10",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.965.10.tgz",
+      "integrity": "sha512-ycwH6Zd2GhuSqdXX9ihbCjeGTB6xOJs+O3+Jb8/zDG9978XU80qs75dfkPJRMNKe5MvBZPuNeFpd4JZKPoUF4g==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -1156,22 +1156,22 @@
       }
     },
     "node_modules/@aws-sdk/util-user-agent-browser": {
-      "version": "3.972.43",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.43.tgz",
-      "integrity": "sha512-NcIr1IOf4PYkcw3eApd6krIcxozVHRGmQObkMmJ4orUlhfM5xUebGaqIUsmdo7K4eXdx48trswc4c0ocP5vqrA==",
+      "version": "3.972.44",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.972.44.tgz",
+      "integrity": "sha512-4m1YHKy4iFnnQnbDUdjTpf3aRm4hkv5elELkZsB9BH6nKp3LQle6wLhodElx0YUjvSni1lI/8HXVw8j2JSWoig==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       }
     },
     "node_modules/@aws-sdk/util-user-agent-node": {
-      "version": "3.973.58",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.58.tgz",
-      "integrity": "sha512-2tudSPpAA0StXbnopuH6k114pUMRpmP+NRG+IK/hWiW20bnQZPxb8zIK7Z66Xlw1QufR512U0v9qwgLqDfH/mA==",
+      "version": "3.973.59",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.973.59.tgz",
+      "integrity": "sha512-Uy7Qy9naXFg8uthAz6jH/YDUIoGVNZD6cGImTpDZ8x0rXm7OE3ZMoe0o8SN5BTtn7n5otdZVnv2/v8Vz8wqJMw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@aws-sdk/core": "^3.977.7",
+        "@aws-sdk/core": "^3.977.8",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -1179,9 +1179,9 @@
       }
     },
     "node_modules/@aws-sdk/xml-builder": {
-      "version": "3.972.38",
-      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.38.tgz",
-      "integrity": "sha512-grf7mzfVxBS5AlsuTvBN7uDpzqohFww9fRPCO+EBSUdvtsYMcPSKdz54h/7XiscqNcUM1Ae1MF7JLHmiYYuzbQ==",
+      "version": "3.972.39",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.39.tgz",
+      "integrity": "sha512-FTti8DS5MMWXNUWiRwXAJeYS+0GHHiMy0+7XOhcwk63ILHmfS2UFy2z/HNpZCSOJJ3P3dnWY6hfYNW3DF0nXUA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@smithy/types": "^4.16.1",


### PR DESCRIPTION
## Summary

- Regenerated `package-lock.json` to pull in the latest compatible transitive dependency versions (169 insertions, 169 deletions)
- All top-level dependency version ranges in `package.json` were already at their latest — no changes needed there
- TypeScript 7 major upgrade was skipped because `@typescript-eslint/parser` and `@typescript-eslint/eslint-plugin` do not yet support it (peer dependency requires `<6.1.0`)

## Verification

- `tsc --noEmit` passes cleanly
- `npm install` completes with 0 vulnerabilities

---
_Generated by [Claude Code](https://claude.ai/code/session_01WSWhMuBTNyP5nWRTev96P2)_