### PR TITLE
chore(deps): update all dependencies and refresh lock file

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6538,9 +6538,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.407",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.407.tgz",
-      "integrity": "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==",
+      "version": "1.5.408",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.408.tgz",
+      "integrity": "sha512-SLoprcYpJ/OH2v2ps0+N5biv9H4/KBT3+YmmDew64TwK5y9j2wv7pMOFY7IorVkyMtEyLSCRlXKLsNlakeAlPw==",
       "dev": true,
       "license": "ISC"
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "clsx": "^2.1.1",
         "drizzle-orm": "^0.45.2",
         "gsap": "^3.15.0",
-        "lucide-react": "^1.31.0",
+        "lucide-react": "^1.32.0",
         "next": "^16.3.1",
         "next-auth": "^5.0.0-beta.32",
         "postgres": "^3.4.9",
@@ -1487,9 +1487,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260811.1.tgz",
-      "integrity": "sha512-i5jqz+ywtOefr0AJbiAc8qxBLfSim/B0WJG7aW3B+pWnoVfMJdUQvi+BWcFKZJ0MoCci3KadTx6g31VfuEEqpQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260815.1.tgz",
+      "integrity": "sha512-7PsLdcz6pT9EMd1EJGZEgMyYRfs0CHxGs62PS2L1w3s6+xGmQcRXKm/zoMftmqZF45JBa4MzFeownRKbRt/x5g==",
       "cpu": [
         "x64"
       ],
@@ -1504,9 +1504,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-NoOUM/nvaDdm2Onlnz33FikWjtatzulNtvwvy4xs0IrHaTCHwC0c8NwIt6s+AI13FkDs02/vm2I3GTPLCT9+hQ==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-60wtg8ng7FVWeOg/UMbZ9Ye0sslpRRAKoftPbdtuH2volq676quxVr6Zm2EjVULH/JFZeCn72dbLlrnbh0Mpcw==",
       "cpu": [
         "arm64"
       ],
@@ -1521,9 +1521,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260811.1.tgz",
-      "integrity": "sha512-sdYq2jL1AD1supa3fsi5O4zTB28wSjvTHj7Migh6/ts8EROPdvrSwv+rdGHhv8HJNAz/wbIAY3wZsi1Rw4uUIg==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260815.1.tgz",
+      "integrity": "sha512-MuqKIHPo0Qyo8MZMmy0lP2B5PeAL7f4T9Fu4Usk3QdbV4JIrKG/OoybN3Ign7m/Dff+L1Oo/ZHydB+hEg1ueFw==",
       "cpu": [
         "x64"
       ],
@@ -1538,9 +1538,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260811.1.tgz",
-      "integrity": "sha512-RIRv4shbu1kg05sD+DHTpSFCNnb5Dl2SkPDMUykqZa508tkPqe7VVw7gO0Q5msTBGyL0FfFrLuRxwwfA8u5Sow==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260815.1.tgz",
+      "integrity": "sha512-XNFtJ5rIqJxnY6ISjkfbhT/ODiWJ6LcBvNbntuPD6I/F2k7aZeKgPaXrvWvKde66LXyzFKzc8Hn+Ydx4shevQg==",
       "cpu": [
         "arm64"
       ],
@@ -1555,9 +1555,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260811.1.tgz",
-      "integrity": "sha512-g6VquwjASlYAibcNW/0E6Zszht4qLkmnXOGwIjjRHl2A0Qz48kVeMcGvyH6eA0G9U3OzZojjYFpP+YeyQmmdjw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260815.1.tgz",
+      "integrity": "sha512-PiIUWrhbMg3quolwjgMvPOd75vKESjT4aDm7nL6mSjL5IOgmpO/zKstXnYfnEH3pq7sC0UCvKlF8ZPcfsh8NMw==",
       "cpu": [
         "x64"
       ],
@@ -6538,9 +6538,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.409",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.409.tgz",
-      "integrity": "sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ==",
+      "version": "1.5.411",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.411.tgz",
+      "integrity": "sha512-gglkxzokjHfawpGxq75XdBV2/l3BAPzrsMs70qgaZdTW5rpV1tC4MdgJVP9fN126bODA4ZJQkn1wryEzJyQXIg==",
       "dev": true,
       "license": "ISC"
     },
@@ -9139,9 +9139,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.31.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.31.0.tgz",
-      "integrity": "sha512-G8u2eEtoHUnUa9f8lbvqDhCiORMnYLdUEo06EEG9MQvHQrInKcX3Pa2TH39MM5qyzRcWETxB0+aOwAPI1g1kEg==",
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.32.0.tgz",
+      "integrity": "sha512-txX56hMFnRxPi1f9/nH69YN8uvAO6a7Y1KSWKjCDAtdD9+soEgmWuCt6iRm1pkxUZo2+YntSdsE1L6bIuKoY8Q==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -9269,16 +9269,16 @@
       }
     },
     "node_modules/miniflare": {
-      "version": "5.20260811.1-alpha",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260811.1-alpha.tgz",
-      "integrity": "sha512-DtOG0BeanIxs2sH0smFvExZD89cBQwGckbHiFkRJrrNAUu3NGClZkUxqu+zy7HYfKBAgq935EMY49vIPm3JVdA==",
+      "version": "5.20260815.0-alpha",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-5.20260815.0-alpha.tgz",
+      "integrity": "sha512-YAaGj4Sh5f4fqHKiMQ8zRHDOOM5IGUVtMhnLIeyjuQfU+9P6hcOTrHUVtbfj/ZPay9Kzik4pWELB39pGgefjiQ==",
       "license": "MIT",
       "peer": true,
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
         "sharp": "0.35.2",
         "undici": "7.29.0",
-        "workerd": "1.20260811.1",
+        "workerd": "1.20260815.1",
         "ws": "8.21.0",
         "youch": "4.1.0-beta.10"
       },
@@ -12304,9 +12304,9 @@
       }
     },
     "node_modules/workerd": {
-      "version": "1.20260811.1",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260811.1.tgz",
-      "integrity": "sha512-kh+FFm55JQ4ssxhHZV9VPdMQq3D1nHxNJgwxMtWGD4dGppJvLySdguTRDKgeNTvgq6heSz+6TTXyPSDGj8Yllw==",
+      "version": "1.20260815.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260815.1.tgz",
+      "integrity": "sha512-8bArFkHmlp7qFEKVPyNzDzHzS35gc2fg0PYBcDtaNLF7UCDryCX2BQnpkUkTHYIy824IRrHOTwOEoTj0sUO2Fg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "peer": true,
@@ -12317,17 +12317,17 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20260811.1",
-        "@cloudflare/workerd-darwin-arm64": "1.20260811.1",
-        "@cloudflare/workerd-linux-64": "1.20260811.1",
-        "@cloudflare/workerd-linux-arm64": "1.20260811.1",
-        "@cloudflare/workerd-windows-64": "1.20260811.1"
+        "@cloudflare/workerd-darwin-64": "1.20260815.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260815.1",
+        "@cloudflare/workerd-linux-64": "1.20260815.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260815.1",
+        "@cloudflare/workerd-windows-64": "1.20260815.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "4.123.0",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.123.0.tgz",
-      "integrity": "sha512-VXo2I1oa0x9aGAKIFPRSQPqTh0RBY5Ktl44YOhNmsJQFUdJKDA2vVTU6Xj+FC2koll6orJqWZN8jbXVIk9O67Q==",
+      "version": "4.124.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.124.0.tgz",
+      "integrity": "sha512-75euoZKjVTJYFy+Xhctt/5JlZL4M6A4xmovZsUlep+6GHcCm14n9VtdGzNIybOW2t8wuNxRj5iMUwjT5E7Ctog==",
       "license": "MIT OR Apache-2.0",
       "peer": true,
       "dependencies": {
@@ -12335,10 +12335,10 @@
         "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
         "esbuild": "0.28.1",
-        "miniflare": "5.20260811.1-alpha",
+        "miniflare": "5.20260815.0-alpha",
         "path-to-regexp": "6.3.0",
         "unenv": "2.0.0-rc.24",
-        "workerd": "1.20260811.1"
+        "workerd": "1.20260815.1"
       },
       "bin": {
         "cf-wrangler": "bin/cf-wrangler.js",
@@ -12352,7 +12352,7 @@
         "fsevents": "2.3.3"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^5.20260811.1"
+        "@cloudflare/workers-types": "^5.20260815.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3801,12 +3801,12 @@
       }
     },
     "node_modules/@smithy/config-resolver": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.7.0.tgz",
-      "integrity": "sha512-2/dD9ftRHTKH7pVdTSHoTGAYW/ruYmqzFeEn2cRRkNLs6GSRzlCoIAz/wSIk3g47t+k5+1JOMoXcI0+PFPV3MA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/config-resolver/-/config-resolver-4.7.2.tgz",
+      "integrity": "sha512-Y1XfSefHIOub9762qm3ShafdlEE/Va8h3kLUeMq765fNeWeNLcOP2YUPr86H1SlyGwZTOqQ67RlBZPZ3k9Djgg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3814,12 +3814,12 @@
       }
     },
     "node_modules/@smithy/core": {
-      "version": "3.33.0",
-      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.0.tgz",
-      "integrity": "sha512-uKbkxgqLyepQDZoq8aRSdUqD1ID//rOqG96ixBhp++O7vBtmwYM6fwldGhr9HJP0iYrdc7GP/AlgzPWEZIrNRg==",
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.2.tgz",
+      "integrity": "sha512-CUGXpnPkVdjUCbix+83sWLW9VFgQOm44MDOx/ihITJMAnOZKvL8YYIc7DR9pP/tZ8CIRvMiON/TucvygqbHO3w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/types": "^4.17.0",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3827,13 +3827,13 @@
       }
     },
     "node_modules/@smithy/credential-provider-imds": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.0.tgz",
-      "integrity": "sha512-2jsPi+7Zv2hSzD9IXR9D7DTqSn7mv4XalzRm+bESh53jiaUS3NKEUbpQFTJP0HhQy9qzZvluxQ3yS24zdRrqsA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+      "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3841,12 +3841,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-browser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.5.0.tgz",
-      "integrity": "sha512-eCi6FfrWRL8ac7qex4t7rjBCytdjUMEYC+zYZeyuCmNA4ozhAbzJ0LDDq8ENXCCeICvdip70HkK3CkMAqbEpqA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-browser/-/eventstream-serde-browser-4.5.2.tgz",
+      "integrity": "sha512-HQ4l596buGUPnypSGfoYKp17GvR0sMMKyc6PQ/NHxLmh8sQjP7h3TRvy+lW/et12UN9BRPAbHJKa4d3XMMVszQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3854,12 +3854,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-config-resolver": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.6.0.tgz",
-      "integrity": "sha512-7ybvufEKK5kYKA+lwp2mu86p/C7R5ieaxObbzscrON8H/4KueZcSr8v9+0vfuBfjdVD2h9L4JoDYt5qfeQ4eRA==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-config-resolver/-/eventstream-serde-config-resolver-4.6.2.tgz",
+      "integrity": "sha512-GVWpmVKiVAvZDr3E0qRPu+A7TzeeMUctuP9SoFpzGx31lenW3Wk8zq7N97p8sJMwLCyVhXcbv5D0UTURCHdH0w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3867,12 +3867,12 @@
       }
     },
     "node_modules/@smithy/eventstream-serde-node": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.5.0.tgz",
-      "integrity": "sha512-43CuEqxQppYeMhnVwdoCOPQkW+j2M5sucwyCQNKxYCC8q5/q8bER3sGVy9deAYbPeQw/PQh8DNTlk8sRRIE14g==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-serde-node/-/eventstream-serde-node-4.5.2.tgz",
+      "integrity": "sha512-WkWkseIHXv+hr6RnrkpEOv5TOPHWLzzlOsocnPCCKsdfCOkBN7qhBn1/Pij9QZynkloJXYsQp9A5ykdIPVL2tg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3880,13 +3880,13 @@
       }
     },
     "node_modules/@smithy/fetch-http-handler": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.0.tgz",
-      "integrity": "sha512-W/exA8T0LEzCQtJ02w4IzaEQPIspgarqZprb7W8FwnYiDowgCrjl2fTQ6FvuSSUnJORuepBF81abmBJwqh+0XQ==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+      "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3894,12 +3894,12 @@
       }
     },
     "node_modules/@smithy/hash-blob-browser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.5.0.tgz",
-      "integrity": "sha512-JtWiqfPRYpdNbu8yZShNWg8RcC1tokPV8fHwfMhbrZMVx25uwz7PKieivyZuhwgUFMN+JKm+LvyrkuvmPZsAvg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-blob-browser/-/hash-blob-browser-4.5.2.tgz",
+      "integrity": "sha512-+fx5GrWB/EElSRl/z+MQXa5RMaGH4ZH/MyZbBgH7CDE053KLD9o4kLGdrBGe8KicU/t22cHzdZs2cVwGL1yt9g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3907,12 +3907,12 @@
       }
     },
     "node_modules/@smithy/hash-node": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.5.0.tgz",
-      "integrity": "sha512-nCxtKLwi0UD9MQdZAgTEDxxU0FHQOdXVfqxrwT8i4Ie9pBM3+SHpkiCFJOoC3XyTOulJIUIr8O+gdHNrpetebQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-node/-/hash-node-4.5.2.tgz",
+      "integrity": "sha512-OcD8fGClTkP0BWHVEAgUp1RZyCw8cKfqTPQ+DgrSF5jvR8zKkw2Aud79L4G/1Fu3QKLcsHExxRIPQCcKx7+xkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3920,12 +3920,12 @@
       }
     },
     "node_modules/@smithy/hash-stream-node": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.5.0.tgz",
-      "integrity": "sha512-Rael2E7rJjlkMtNGC4ZtlFhRYjwpGTsNWkxPXWUMQTwx9mNSZw+yW+57STyv/AVBohtDbvwuP781yNK5NHHxWg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/hash-stream-node/-/hash-stream-node-4.5.2.tgz",
+      "integrity": "sha512-0sx3A9RyCV8taQ1UM9P7K9JFH2bsLXhdIr85vNNXkhq7Q9TqUdm+XxGiBuInq76aA7vBdvUQFvvyBoB95DJf3Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3933,12 +3933,12 @@
       }
     },
     "node_modules/@smithy/invalid-dependency": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.5.0.tgz",
-      "integrity": "sha512-hSAubiSKr2oMpv1FDimJI9ULauObVtttLViQlm2Poz48U70O6T436e0KsPNeft6v86S49HqyZ/NZH2rOdp3AEw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/invalid-dependency/-/invalid-dependency-4.5.2.tgz",
+      "integrity": "sha512-VONOgtCxIXtwXrLVZPUdxOELYpkFzNizkpbQE5CrJ/OEh12Osx+LVXsLEAF+JcvVqPODmUoOUaovlOjCQHTOow==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3958,12 +3958,12 @@
       }
     },
     "node_modules/@smithy/md5-js": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.5.0.tgz",
-      "integrity": "sha512-TFMjrlJ7uAux03ilnH1Gl3J4NpKAZQYnq07aGT0mPgg3xBmYMjQ3mEjxOY+QYxSx1NXIr1sVdbQ6MbM7H3KQzg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/md5-js/-/md5-js-4.5.2.tgz",
+      "integrity": "sha512-EC8CXhy/Y3DHniNBPK63ECkYir91IpFhIbVOo/Z7y75hO3RMFY0v+b6MUPLVp0TBtTRo+A5uU73yqyrTecTJmw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3971,12 +3971,12 @@
       }
     },
     "node_modules/@smithy/middleware-content-length": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.5.0.tgz",
-      "integrity": "sha512-Qyi0IVOOmNP48o92eB6d47YMLLS1vq6YJoqm45PNR4M1PoOzV4HkmgjajNcaGEENhMABK8n91Ws3WmasqHHfMA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-content-length/-/middleware-content-length-4.5.2.tgz",
+      "integrity": "sha512-43Ixsc2OE5rhruhc9a1vETUCmK3Yh1AIbg2+wwQUgloOIti2FgPHmPLLBkjIqx8vdmpABtsVlhazNr5TMZKJmA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3984,12 +3984,12 @@
       }
     },
     "node_modules/@smithy/middleware-endpoint": {
-      "version": "4.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.7.0.tgz",
-      "integrity": "sha512-GBsFfpfmaxJCkoT4JoSQSvmtlnEF4yCL7tIfnTIic5NSgk6UdK9g1ooDerLVsTqtsL+SPe0FKrURCpWdJwj6uA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.7.2.tgz",
+      "integrity": "sha512-7HgK3/pQQHcD5w9lOPtK53/eDMKDp324Nd4KZ8XvxlcKHiWytuM9VwVOB2iy3rutsz/N1WNEWBkaRBayrGnuog==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -3997,12 +3997,12 @@
       }
     },
     "node_modules/@smithy/middleware-retry": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.8.0.tgz",
-      "integrity": "sha512-OPhP7KoqB/c3lb11ul4R1sG+6zp247WB6Q8O6sDlHmYr8aMMoPt+N+rCJPKgZi0MuEB1di3YcSqBxuLikidRkQ==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.8.2.tgz",
+      "integrity": "sha512-wj0BTZ6SC7YI8hSLMbZCO1BP7k8JOuSUHjRYrZJApqNEiHL6jxaLs5Sr92EeXu5CuVzZOUCFUuewXusWxps0bQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4010,12 +4010,12 @@
       }
     },
     "node_modules/@smithy/middleware-serde": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.5.0.tgz",
-      "integrity": "sha512-KMlz8uq4EX+dk3TiH+jw8L5zMV7zrpQwtKN51eMHwlsg6xb8i84jXZ0aa1MLbJK+0C+bqidH4HBKRqCEbShy7Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-serde/-/middleware-serde-4.5.2.tgz",
+      "integrity": "sha512-5Qeqkw4IdmUQUGR/FRImBruFcnXiwGC8+EOVH377bonkQF66temzxM4HbCnOOQb8U/SClP1IdlFbC7CTmKux4Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4023,12 +4023,12 @@
       }
     },
     "node_modules/@smithy/middleware-stack": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.5.0.tgz",
-      "integrity": "sha512-fnPgT1ni9f36a5ekQfTLXYpJcE8/A6lKQ2X+AtsS97StRgIaAFf6N3p3wsrL2xgfsl8PreEHQ3eYvYpEVEgD+Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/middleware-stack/-/middleware-stack-4.5.2.tgz",
+      "integrity": "sha512-db1TDSBA03WtomPMLWPy69L85vEaQbbnDHlmCYQ7hIqOdD22K+k8GlsVYdafYKaFkJaJW2OvcgcXOELGfhtptA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4036,12 +4036,12 @@
       }
     },
     "node_modules/@smithy/node-config-provider": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.6.0.tgz",
-      "integrity": "sha512-DXGmwJDsQzx033lbe5+mMnK88n9PK14akJb67GQFmxD7PXPa1+AbawssOZA8q9Y4Wp+6M8a9RKfFYYoRCdfcuw==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-config-provider/-/node-config-provider-4.6.2.tgz",
+      "integrity": "sha512-zMrXu/O5tPa7GLtra8L4wFG6DACcXT9QV4Ay+WEAjUhXm1dVq7c/q9Qv9gkJZNLY8hmQKg08778kDcxpKNMqOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4049,13 +4049,13 @@
       }
     },
     "node_modules/@smithy/node-http-handler": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.0.tgz",
-      "integrity": "sha512-ssHIZsadPUA3lGdnoByxfnjtb9xPYQLvdfJRLKIwxOoa6tO1suG4sLFSsgd7D/CsvYd8QbBIuKTImuJha5l6aQ==",
+      "version": "4.11.2",
+      "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.2.tgz",
+      "integrity": "sha512-avwAh9HM3h2lcfjvP3zYIZGf+XVgLQ91wOJ2qoFbNpW1UZeZb33aGlhTZvtkANHfcGhJroRY64525OjfgOg30g==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.33.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4063,12 +4063,12 @@
       }
     },
     "node_modules/@smithy/protocol-http": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.6.0.tgz",
-      "integrity": "sha512-8XwMdtETS0/pEGPa9wbWu1XQmFIrgPUx6yjxcsR0oVyXYeY15JRpwz3RJHIhpr0uXgEJDPbQbdF5eLcfagI7pA==",
+      "version": "5.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/protocol-http/-/protocol-http-5.6.2.tgz",
+      "integrity": "sha512-Asd04MaxODN6FNY8EPTeCAM4kPNi3jDUAjZU0Y4F9rHvpLUrrUo7KLcxFgSthywFr6dZfIyDLIJda6jxmVTk5w==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4076,13 +4076,13 @@
       }
     },
     "node_modules/@smithy/signature-v4": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.0.tgz",
-      "integrity": "sha512-hCynhm22wMJ8wTF9crcwu8mxggtUrSLLJgDcGUvYFBqpofxycYJCGKOMYg4xtPPFtgNiDJSYmhsWLTrcU/g59Q==",
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.2.tgz",
+      "integrity": "sha512-P7Ki6px6OOrxVtx8K7nLmyx4SlXUW/uTKDdMG44UHefmPGSRMBKe2v+TM59WdLcpUIrBrnuCsIqiM2MbsZjmhw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4090,13 +4090,13 @@
       }
     },
     "node_modules/@smithy/smithy-client": {
-      "version": "4.15.0",
-      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.15.0.tgz",
-      "integrity": "sha512-7ay2gfzkVK6Sj2zqmMhztWM01yK6oSp1UmnaCCcrhqqrqmWeYFI5wecAb4WxGtO3u6letM/JcrgtVgjhutvdpA==",
+      "version": "4.15.2",
+      "resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.15.2.tgz",
+      "integrity": "sha512-qweA7dHwcWmq8IN2mIGo7nAfeji1nwWBra+P3nz4R8W8yoQYE6Iy2bN33I0W3d50MN/V5EiDY/nElr4EHITsrg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
-        "@smithy/types": "^4.17.0",
+        "@smithy/core": "^3.33.2",
+        "@smithy/types": "^4.17.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4104,9 +4104,9 @@
       }
     },
     "node_modules/@smithy/types": {
-      "version": "4.17.0",
-      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.0.tgz",
-      "integrity": "sha512-Aw4joiM0ZdErpo39lCj8phT2lxoiKZV+KZzBxnnQhWVtU2Is/WffQSL04uUWRcXUse9Ln8vXZK6V/FwqRVnQpg==",
+      "version": "4.17.2",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+      "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.6.2"
@@ -4116,12 +4116,12 @@
       }
     },
     "node_modules/@smithy/url-parser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.5.0.tgz",
-      "integrity": "sha512-9XqVa8o2M0qbNRMqFINHU+VivRz5ojSTHK+QJBs/JnJKNCKLtB90HN/0nZvDjHCLdQWKenxPy5x4E4cigQUt0A==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/url-parser/-/url-parser-4.5.2.tgz",
+      "integrity": "sha512-xqZcyU/YjOt9ofe8WM1y9aCaAmxel2iRiHpkT0x2BN++mRXw0M4VdxPAOtuux279JndY6wWMiOt5BJ2xmAuMYA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4129,12 +4129,12 @@
       }
     },
     "node_modules/@smithy/util-base64": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.6.0.tgz",
-      "integrity": "sha512-x6hwcXhO8TjkC2lWhyNWyOZ4iFU42uk1XRSHIYueGIk4ljqc6UQ66K/AATpXlCo5uJkwDuF2RxCZ4zi2UKDXAw==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-base64/-/util-base64-4.6.2.tgz",
+      "integrity": "sha512-wTQX1hPfElIqY6AzM/s6c4UgpMxCL4MwJ5u6340ksLPq78lur6Y+keheIDk5gMX4G3KFh4MERcDt6xhRq+ie1Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4142,12 +4142,12 @@
       }
     },
     "node_modules/@smithy/util-body-length-browser": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.5.0.tgz",
-      "integrity": "sha512-ROj0xwDCkpoNNzYYg+qF5viIYBhqvw/TaFuqn2lcgGnSx5KRzQcAetjP7dOACe+557L59+fLCRWouo3pe80q0Q==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-browser/-/util-body-length-browser-4.5.2.tgz",
+      "integrity": "sha512-QyeUSin/R2nz0hXZ5ObTvhmCQomsr6+ZyHygab5AH5+fTY5xVDQeX1DFKp9uPEwOs6RW26jEn9yqq+4yqIZDrA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4155,12 +4155,12 @@
       }
     },
     "node_modules/@smithy/util-body-length-node": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.5.0.tgz",
-      "integrity": "sha512-VTvUXjQJ25QxzJQXpUI/5UNIVc7ZTX4N1+6PjDpYjIquAuoDm7jPPq6T5q2eFZRLq7eg72/xnUmXkxnTtgQMlg==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-body-length-node/-/util-body-length-node-4.5.2.tgz",
+      "integrity": "sha512-SErsW8pBKTCkFEA1RoChwW6/8JYzdcWqWDOsRP0xOtxMYsHOUMcldkcQjtujpKSy2FtlywqygCOxSKarc4TAZw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4181,12 +4181,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-browser": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.6.0.tgz",
-      "integrity": "sha512-8iK8mH+xR5pqXlcEreHYVH7dfNCuV691ES2vUFqkBt7W83p18xUWFzZYs3vJ+CdllQdXFCAtV8XTcY5g0Jtt8Q==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.6.2.tgz",
+      "integrity": "sha512-wENSdyLXVzupl1nyPK7JP/wt6Lkph/psRgocKli5NLh7O936L66FrZQ/I9HBHwZ5N0Z4MJUoj8qNdw+/6cTRgA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4194,12 +4194,12 @@
       }
     },
     "node_modules/@smithy/util-defaults-mode-node": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.5.0.tgz",
-      "integrity": "sha512-uNOH0bg1N3AtEIxkNAWPkwuDn3SJ/5nLu488CHlYi3okmN4VV/n4L6IHGC2dBajVxBSEjVcx/wYAJGypEU7Dug==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.5.2.tgz",
+      "integrity": "sha512-3915rhdCibo7Do927AFV6pXxsIiaKOZGGexJ3LnT2l5CgJZi3DPqZ2ZMhYTIPjiRA3asHhPe0gaFBtxuqXC8aA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4207,12 +4207,12 @@
       }
     },
     "node_modules/@smithy/util-endpoints": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.7.0.tgz",
-      "integrity": "sha512-RLDqLt4BMGnKQ4dIW/njlhkwzjXlrD4Ej5w+ldkyuafUIMaxAsgMT7T2mir7k83dfiyGMKdnpFDOTkMDGYAXyg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-endpoints/-/util-endpoints-3.7.2.tgz",
+      "integrity": "sha512-16wQS3r4gXctr9/uYB0OUAUOm1LZLUKAsBeG364l64OalFwsRRvgO+AjL3OYxmxt060z1ExchX2ayrNVfM0r9Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4220,12 +4220,12 @@
       }
     },
     "node_modules/@smithy/util-middleware": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.5.0.tgz",
-      "integrity": "sha512-eRH8CHJxn962SKib4FIJB0tIooDAwUPpO5ezCqnUuQbY3mKFgvmV+CdFeODr6WgkPKtlOqwuKfeMpzfNSKfBaw==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-4.5.2.tgz",
+      "integrity": "sha512-wmfA04AZqTwu10EWGKUu4dm/3BZfSedqlqAiQPWVr8OkwFh0MovRDBwc48Pzd2YEEjqpI0JwXVk65TBarff3wQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4233,12 +4233,12 @@
       }
     },
     "node_modules/@smithy/util-retry": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.6.0.tgz",
-      "integrity": "sha512-J6ws8wYMJjPI0HBBxqCuHkHAfr1Xd/H/MKMrUVHiEhRUHWXZ2R6i6E8XTBAp55msMB8Q436D56Cl2tjgwOHfog==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-retry/-/util-retry-4.6.2.tgz",
+      "integrity": "sha512-q6MXFNu+W4ZCNdNKutzDLP/Hzumd1FU9CQX++P/7ylanYIYiGhgZwSzwZWAw+G1RNcfY+RBYv61XcGlSYhj+BA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4246,12 +4246,12 @@
       }
     },
     "node_modules/@smithy/util-stream": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.8.0.tgz",
-      "integrity": "sha512-wWKVGUXcGZnxeZM50oE6jX1tObuixzweQYp3XP+IUQe4kdriUsJxKK2eQ8aYwbRzNGhEt2Cc93Wfco4YR57F2Q==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-stream/-/util-stream-4.8.2.tgz",
+      "integrity": "sha512-R+S7jmu8VdbtOygMUSIGfkmOBp0SowT8+8LZdk21oXdmmKfN4G/bwN5IGIi0UH3RwWc9KJWDH1Dzm45DClyUvw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4259,12 +4259,12 @@
       }
     },
     "node_modules/@smithy/util-utf8": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.5.0.tgz",
-      "integrity": "sha512-0jP6o0EBoQq6qyipoxwOkQSuMV8h0T6fe3N8dY/XyWBAxRkoIAVJklufpW7Br8zqfcnoc0LfeBPPXPTSaCYp3g==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-4.5.2.tgz",
+      "integrity": "sha512-7wNWV7SugHpcMA7uzEawJNpE0GrasXM7a9E+1+Wm6NxVuDClESac/AKt+G7jMZNUz5vBLWqKlqVV7Sv7AtUr6Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -4272,12 +4272,12 @@
       }
     },
     "node_modules/@smithy/util-waiter": {
-      "version": "4.6.0",
-      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.6.0.tgz",
-      "integrity": "sha512-6vcYgT4Tr2norfflY2FPxu536GGPC+P0KFfy4DoLWgeuVMbloksaVvKyV/OE94AtI9KTTHBXworzKXxctfUTAg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/@smithy/util-waiter/-/util-waiter-4.6.2.tgz",
+      "integrity": "sha512-TNNK01i1HiSAR6hBF94J7q338JgEaHPrP8QKRSeQBsbSbw5O4+YGdZYitmsTeEWvHGX+2R/oQ7BzxyAjeZxuWg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@smithy/core": "^3.32.0",
+        "@smithy/core": "^3.33.2",
         "tslib": "^2.6.2"
       },
       "engines": {
@@ -6538,9 +6538,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.406",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.406.tgz",
-      "integrity": "sha512-hWH5ORBi3d0IipnMh7BN5GDTaAmrSSSWmznwt2zltdiRNEWoEQyTwF0FFSBxzHO7hLSRT6loQu3IQGV0wg/Tvg==",
+      "version": "1.5.407",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.407.tgz",
+      "integrity": "sha512-4R8XgQOdfxexCd/u63lRm6wCHjECwI45MV9wxAs2ggtfWe2hwlo1ql97jKsju2IcJ+jFSTwBssyYoiWhh7mauQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -8706,9 +8706,9 @@
       }
     },
     "node_modules/jose": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.8.tgz",
-      "integrity": "sha512-Bsdjwm3Qsd/P0jR+BHDe3LytDfY7WBq2HmCCLIwuVRHMuEC9ae7/R474GIUdF1NgCyZjzVo/A9DOiOBtXq8ZoQ==",
+      "version": "6.2.9",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.9.tgz",
+      "integrity": "sha512-XrchZOFZUl/T3vTwRe8XK+cJrGtMF4th1ARnDfwbBXFKThGhlsxEE4Zu03AD/bjJSt/9jT/mxrOCkJWOg77aPA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/panva"

--- a/package-lock.json
+++ b/package-lock.json
@@ -5709,9 +5709,9 @@
       }
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.11.14",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.14.tgz",
-      "integrity": "sha512-JyJ954WzuIR8/FFzX0o5krdSTrBAkcCSRfWSleRsIHSWV+cZe2FI1PKggVkFke1hBldRs+LRxUczzE9iPmgZww==",
+      "version": "2.11.15",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.11.15.tgz",
+      "integrity": "sha512-FwMjJJ7HnyZpWe+oWxegG0fezZyBZUagI5LZEoO3GCbtbKNwRfMH9Ue5d5v01PNePBy1QSfPSDTTeVL0Hb9EzA==",
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.cjs"
@@ -6538,9 +6538,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.408",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.408.tgz",
-      "integrity": "sha512-SLoprcYpJ/OH2v2ps0+N5biv9H4/KBT3+YmmDew64TwK5y9j2wv7pMOFY7IorVkyMtEyLSCRlXKLsNlakeAlPw==",
+      "version": "1.5.409",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.409.tgz",
+      "integrity": "sha512-ChI4N44d0B4A6C8prnNjMOaGgE59fUyEVYcRYm2XEXIjMbbvF5i9UL1cblDbpGqiU0uS8FE8UcKxqZqTXdmzbQ==",
       "dev": true,
       "license": "ISC"
     },
@@ -7882,9 +7882,9 @@
       }
     },
     "node_modules/get-tsconfig": {
-      "version": "4.14.2",
-      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.2.tgz",
-      "integrity": "sha512-XpwZALwwl/BaKTAyC6+c5T8y6kCg2jk+XGqOVrKIQmW49pNypYLMRjCUXqa28tQgJlhS2RlzP7sc+Rx7W6qsfw==",
+      "version": "4.14.3",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.3.tgz",
+      "integrity": "sha512-++QEw4DIY7WGoukz+/+A/8dGYPT9l9yIadnmSgZ8Rjr3YVSVDipQSO9CdnJo9ePqFqUUqh+wk9uIaoiAwsiPkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "clsx": "^2.1.1",
     "drizzle-orm": "^0.45.2",
     "gsap": "^3.15.0",
-    "lucide-react": "^1.31.0",
+    "lucide-react": "^1.32.0",
     "next": "^16.3.1",
     "next-auth": "^5.0.0-beta.32",
     "postgres": "^3.4.9",


### PR DESCRIPTION
## Summary

- Merged latest `main` into the dependency branch
- Bumped `lucide-react` from `^1.31.0` to `^1.32.0` (minor)
- Ran `npm update` to pull all sub-dependencies to their latest compatible versions
- Refreshed `package-lock.json` with latest sub-dependency versions

## Updated packages

| Package | From | To | Type |
|---------|------|----|------|
| `lucide-react` | ^1.31.0 | ^1.32.0 | minor |

## Updated sub-dependencies

- `electron-to-chromium` 1.5.409 → 1.5.411
- `wrangler` 4.123.0 → 4.124.0
- `workerd` / `miniflare` / `@cloudflare/workerd-*` 1.20260811.1 → 1.20260815.1

## Skipped upgrades

- **TypeScript 7.0.2** — blocked by `@typescript-eslint/parser@8.67.0` which requires `typescript >=4.8.4 <6.1.0`. No version of `typescript-eslint` supports TS 7 yet.

## Verification

- `tsc --noEmit` — passes cleanly
- No peer dependency errors (only existing warnings from next-auth beta)
- 0 vulnerabilities reported by `npm audit`