### PR TITLE
Creator-Verwaltung im Dashboard auf Postgres umstellen

### DIFF
--- a/src/app/api/creators/route.ts
+++ b/src/app/api/creators/route.ts
@@ -1,0 +1,74 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listCreators, toPublicCreator, normalizeMinecraftUuid } from "@/lib/creators";
+
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+/**
+ * Public read-only REST API for creators.
+ *
+ *   GET /api/creators                     → all creators
+ *   GET /api/creators?uuid=<minecraft>    → a single creator by Minecraft UUID
+ *   GET /api/creators?name=<name>         → a single creator by name (case-insensitive)
+ *   GET /api/creators?limit=&offset=      → pagination
+ *   GET /api/creators?format=raw          → dashboard shape instead of the legacy CMS shape
+ *
+ * The default payload keeps the legacy CMS field names (`Minecraft_username`,
+ * `Name`, `Platforms`) so existing consumers do not have to change.
+ */
+export async function GET(req: NextRequest) {
+  const { searchParams } = req.nextUrl;
+  const raw = searchParams.get("format") === "raw";
+  const uuidParam = searchParams.get("uuid");
+  const nameParam = searchParams.get("name");
+
+  try {
+    const all = await listCreators();
+
+    if (uuidParam || nameParam) {
+      const uuid = uuidParam ? normalizeMinecraftUuid(uuidParam) : null;
+      const entry = all.find((c) =>
+        uuidParam
+          ? c.minecraftUuid === uuid
+          : c.name.toLowerCase() === String(nameParam).trim().toLowerCase(),
+      );
+      if (!entry)
+        return NextResponse.json(
+          { error: "Not found" },
+          { status: 404, headers: CORS },
+        );
+      return NextResponse.json(
+        { data: raw ? entry : toPublicCreator(entry) },
+        {
+          headers: {
+            ...CORS,
+            "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+          },
+        },
+      );
+    }
+
+    const limit = Math.min(Number(searchParams.get("limit") ?? "200") || 200, 200);
+    const offset = Math.max(Number(searchParams.get("offset") ?? "0") || 0, 0);
+    const page = all.slice(offset, offset + limit);
+
+    return NextResponse.json(
+      {
+        data: raw ? page : page.map(toPublicCreator),
+        meta: { total: all.length, limit, offset },
+      },
+      {
+        headers: {
+          ...CORS,
+          "Cache-Control": "public, s-maxage=60, stale-while-revalidate=300",
+        },
+      },
+    );
+  } catch (e) {
+    console.error("[creators public GET]", e);
+    return NextResponse.json({ error: String(e) }, { status: 500, headers: CORS });
+  }
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}

--- a/src/app/api/dashboard/creators/[id]/route.ts
+++ b/src/app/api/dashboard/creators/[id]/route.ts
@@ -1,0 +1,141 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getDb, schema } from "@/lib/db";
+import { ensureCreatorTables } from "@/lib/db/migrate";
+import { normalizeMinecraftUuid, sanitizeChannels } from "@/lib/creators";
+import { eq } from "drizzle-orm";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+/**
+ * postgres.js surfaces the driver error (with the SQLSTATE code) as `cause`,
+ * while the wrapping drizzle error only carries the failed query text — so the
+ * code has to be read off the cause to recognise a unique violation.
+ */
+function isUniqueViolation(e: unknown) {
+  const err = e as { code?: string; cause?: { code?: string } };
+  return err?.code === "23505" || err?.cause?.code === "23505";
+}
+
+function handleError(e: unknown, scope: string) {
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error(`[creators ${scope}]`, e);
+  if (isUniqueViolation(e)) {
+    return NextResponse.json(
+      { error: "Diese Minecraft-UUID ist bereits einem Creator zugeordnet." },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: msg }, { status: 500 });
+}
+
+/**
+ * PATCH — update name, UUID and/or the channel list. Channels are replaced
+ * wholesale: the submitted order becomes the stored `sort_order`.
+ */
+export async function PATCH(
+  req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const creatorId = Number(id);
+  if (!Number.isInteger(creatorId))
+    return NextResponse.json({ error: "Ungültige ID." }, { status: 400 });
+
+  try {
+    await ensureCreatorTables();
+    const body = await req.json();
+    const db = getDb();
+
+    const update: { name?: string; minecraft_uuid?: string; updated_at: Date } = {
+      updated_at: new Date(),
+    };
+
+    if (body.name !== undefined) {
+      const name = String(body.name).trim();
+      if (!name)
+        return NextResponse.json(
+          { error: "Name ist erforderlich." },
+          { status: 400 },
+        );
+      update.name = name;
+    }
+
+    if (body.minecraftUuid !== undefined) {
+      const uuid = normalizeMinecraftUuid(body.minecraftUuid);
+      if (!uuid)
+        return NextResponse.json(
+          { error: "Ungültige Minecraft-UUID." },
+          { status: 400 },
+        );
+      update.minecraft_uuid = uuid;
+    }
+
+    const [updated] = await db
+      .update(schema.creators)
+      .set(update)
+      .where(eq(schema.creators.id, creatorId))
+      .returning();
+
+    if (!updated)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    let channels = undefined;
+    if (body.channels !== undefined) {
+      channels = sanitizeChannels(body.channels);
+      await db
+        .delete(schema.creatorChannels)
+        .where(eq(schema.creatorChannels.creator_id, creatorId));
+      if (channels.length > 0) {
+        await db.insert(schema.creatorChannels).values(
+          channels.map((c, i) => ({
+            creator_id: creatorId,
+            platform: c.platform,
+            url: c.url,
+            sort_order: i,
+          })),
+        );
+      }
+    }
+
+    return NextResponse.json({
+      data: {
+        id: updated.id,
+        name: updated.name,
+        minecraftUuid: updated.minecraft_uuid,
+        sortOrder: updated.sort_order,
+        channels,
+      },
+    });
+  } catch (e) {
+    return handleError(e, "PATCH");
+  }
+}
+
+/** DELETE — remove a creator; channels are dropped by the cascade. */
+export async function DELETE(
+  _req: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const { id } = await params;
+  const creatorId = Number(id);
+  if (!Number.isInteger(creatorId))
+    return NextResponse.json({ error: "Ungültige ID." }, { status: 400 });
+
+  try {
+    await ensureCreatorTables();
+    await getDb().delete(schema.creators).where(eq(schema.creators.id, creatorId));
+    return new NextResponse(null, { status: 204 });
+  } catch (e) {
+    return handleError(e, "DELETE");
+  }
+}

--- a/src/app/api/dashboard/creators/order/route.ts
+++ b/src/app/api/dashboard/creators/order/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getDb, schema } from "@/lib/db";
+import { ensureCreatorTables } from "@/lib/db/migrate";
+import { eq } from "drizzle-orm";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+/**
+ * PUT — persist the creator display order. The body carries the full list of
+ * creator ids in the desired order; each position becomes that row's
+ * `sort_order`, which is what the public listing sorts by.
+ */
+export async function PUT(req: NextRequest) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    await ensureCreatorTables();
+    const body = await req.json();
+    const ids = Array.isArray(body.ids) ? body.ids.map(Number) : [];
+
+    if (ids.length === 0 || ids.some((id: number) => !Number.isInteger(id)))
+      return NextResponse.json(
+        { error: "ids muss eine Liste von Creator-IDs sein." },
+        { status: 400 },
+      );
+
+    const db = getDb();
+    for (let i = 0; i < ids.length; i++) {
+      await db
+        .update(schema.creators)
+        .set({ sort_order: i, updated_at: new Date() })
+        .where(eq(schema.creators.id, ids[i]));
+    }
+
+    return NextResponse.json({ data: { ids } });
+  } catch (e) {
+    console.error("[creators order PUT]", e);
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/src/app/api/dashboard/creators/route.ts
+++ b/src/app/api/dashboard/creators/route.ts
@@ -1,0 +1,112 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getDb, schema } from "@/lib/db";
+import { ensureCreatorTables } from "@/lib/db/migrate";
+import {
+  listCreators,
+  normalizeMinecraftUuid,
+  sanitizeChannels,
+} from "@/lib/creators";
+import { sql } from "drizzle-orm";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+/**
+ * postgres.js surfaces the driver error (with the SQLSTATE code) as `cause`,
+ * while the wrapping drizzle error only carries the failed query text — so the
+ * code has to be read off the cause to recognise a unique violation.
+ */
+function isUniqueViolation(e: unknown) {
+  const err = e as { code?: string; cause?: { code?: string } };
+  return err?.code === "23505" || err?.cause?.code === "23505";
+}
+
+function handleError(e: unknown, scope: string) {
+  const msg = e instanceof Error ? e.message : String(e);
+  console.error(`[creators ${scope}]`, e);
+  if (isUniqueViolation(e)) {
+    return NextResponse.json(
+      { error: "Diese Minecraft-UUID ist bereits einem Creator zugeordnet." },
+      { status: 409 },
+    );
+  }
+  return NextResponse.json({ error: msg }, { status: 500 });
+}
+
+/** GET — list all creators with their channels. */
+export async function GET() {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    return NextResponse.json({ data: await listCreators() });
+  } catch (e) {
+    return handleError(e, "GET");
+  }
+}
+
+/** POST — create a creator together with its channels. */
+export async function POST(req: NextRequest) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    await ensureCreatorTables();
+    const body = await req.json();
+
+    const name = String(body.name ?? "").trim();
+    if (!name)
+      return NextResponse.json(
+        { error: "Name ist erforderlich." },
+        { status: 400 },
+      );
+
+    const minecraftUuid = normalizeMinecraftUuid(body.minecraftUuid);
+    if (!minecraftUuid)
+      return NextResponse.json(
+        { error: "Ungültige Minecraft-UUID." },
+        { status: 400 },
+      );
+
+    const channels = sanitizeChannels(body.channels);
+    const db = getDb();
+
+    // New creators go to the end of the list.
+    const [{ max }] = await db
+      .select({ max: sql<number>`COALESCE(MAX(${schema.creators.sort_order}), -1)` })
+      .from(schema.creators);
+
+    const [created] = await db
+      .insert(schema.creators)
+      .values({ name, minecraft_uuid: minecraftUuid, sort_order: Number(max) + 1 })
+      .returning();
+
+    if (channels.length > 0) {
+      await db.insert(schema.creatorChannels).values(
+        channels.map((c, i) => ({
+          creator_id: created.id,
+          platform: c.platform,
+          url: c.url,
+          sort_order: i,
+        })),
+      );
+    }
+
+    return NextResponse.json(
+      {
+        data: {
+          id: created.id,
+          name: created.name,
+          minecraftUuid: created.minecraft_uuid,
+          sortOrder: created.sort_order,
+          channels,
+        },
+      },
+      { status: 201 },
+    );
+  } catch (e) {
+    return handleError(e, "POST");
+  }
+}

--- a/src/app/creators/page.tsx
+++ b/src/app/creators/page.tsx
@@ -4,6 +4,7 @@ import Creators, { Creator, LiveStatus } from "@/components/page/creators";
 import TopPage from "@/components/page/top";
 import { getServerLocale } from "@/lib/i18n/server";
 import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import { getPublicCreators } from "@/lib/creators";
 
 const META_COPY = {
   en: {
@@ -26,13 +27,11 @@ export async function generateMetadata(): Promise<Metadata> {
 
 async function getCreatorsData() {
   try {
-    const creatorsRes = await fetch(
-      "https://cms.onthepixel.net/items/Creators?fields=*.*.*",
-      { next: { revalidate: 300 } }
-    );
-    if (!creatorsRes.ok) return { creators: [], followersMap: {}, liveMap: {} };
-    const creatorsData = await creatorsRes.json();
-    const creators: Creator[] = creatorsData.data || [];
+    // Creators are managed in the admin dashboard and stored in Postgres.
+    const creators: Creator[] = await getPublicCreators();
+    if (creators.length === 0) {
+      return { creators: [], followersMap: {}, liveMap: {} };
+    }
 
     const [followersResults, liveResults] = await Promise.all([
       Promise.all(

--- a/src/app/dashboard/creators/creators-dashboard.tsx
+++ b/src/app/dashboard/creators/creators-dashboard.tsx
@@ -1,109 +1,587 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useMemo } from "react";
 import Image from "next/image";
-import { Users, Search, ExternalLink, RefreshCw } from "lucide-react";
+import {
+  Users,
+  Search,
+  RefreshCw,
+  Plus,
+  Pencil,
+  Trash2,
+  X,
+  Save,
+  Loader2,
+  AlertCircle,
+  ChevronUp,
+  ChevronDown,
+  Link as LinkIcon,
+  GripVertical,
+} from "lucide-react";
 import {
   FaYoutube,
   FaTwitch,
+  FaTiktok,
   FaInstagram,
   FaTwitter,
+  FaDiscord,
+  FaWhatsapp,
   FaGlobe,
 } from "react-icons/fa";
 import AuthGuard from "../auth-guard";
 
-interface Platform {
-  Icons: string;
-  Link: string;
+/* --- Types --- */
+
+interface Channel {
+  platform: string;
+  url: string;
 }
 
 interface Creator {
-  Minecraft_username: string;
-  Name: string;
-  Platforms: Platform[];
+  id: number;
+  name: string;
+  minecraftUuid: string;
+  sortOrder: number;
+  channels: Channel[];
 }
 
-const PLATFORM_ICONS: Record<string, React.ReactNode> = {
-  youtube: <FaYoutube size={13} className="text-red-400" />,
-  twitch: <FaTwitch size={13} className="text-purple-400" />,
-  instagram: <FaInstagram size={13} className="text-pink-400" />,
-  twitter: <FaTwitter size={13} className="text-blue-400" />,
-  x_twitter: <FaTwitter size={13} className="text-blue-400" />,
+type Draft = {
+  id?: number;
+  name: string;
+  minecraftUuid: string;
+  channels: Channel[];
 };
 
-function PlatformBadge({ platform }: { platform: Platform }) {
-  const key = platform.Icons.toLowerCase();
-  const icon = PLATFORM_ICONS[key] ?? <FaGlobe size={13} className="text-white/40" />;
+/* --- Platform metadata (mirrors the icon mapping on the public page) --- */
+
+const PLATFORMS: { value: string; label: string; icon: React.ReactNode }[] = [
+  { value: "youtube", label: "YouTube", icon: <FaYoutube className="text-red-500" /> },
+  { value: "twitch", label: "Twitch", icon: <FaTwitch className="text-purple-500" /> },
+  { value: "tiktok", label: "TikTok", icon: <FaTiktok className="text-white" /> },
+  { value: "instagram", label: "Instagram", icon: <FaInstagram className="text-pink-500" /> },
+  { value: "x_twitter", label: "X / Twitter", icon: <FaTwitter className="text-blue-400" /> },
+  { value: "discord", label: "Discord", icon: <FaDiscord className="text-indigo-500" /> },
+  { value: "whatsapp", label: "WhatsApp", icon: <FaWhatsapp className="text-green-400" /> },
+  { value: "website", label: "Website", icon: <FaGlobe className="text-white/40" /> },
+];
+
+function platformIcon(platform: string) {
   return (
-    <a
-      href={platform.Link}
-      target="_blank"
-      rel="noopener noreferrer"
-      className="inline-flex items-center gap-1 rounded-md bg-white/5 px-2 py-1 text-xs text-white/60 transition-colors hover:bg-white/10 hover:text-white"
-    >
-      {icon}
-      {platform.Icons}
-    </a>
+    PLATFORMS.find((p) => p.value === platform.toLowerCase())?.icon ?? (
+      <FaGlobe className="text-white/40" />
+    )
   );
 }
 
-function CreatorRow({ creator }: { creator: Creator }) {
+function platformLabel(platform: string) {
+  return PLATFORMS.find((p) => p.value === platform.toLowerCase())?.label ?? platform;
+}
+
+const EMPTY_DRAFT: Draft = { name: "", minecraftUuid: "", channels: [] };
+
+/**
+ * Follower counts come from the public stats service, which resolves a creator
+ * by name and reads its primary (first) channel.
+ */
+const FOLLOWERS_API = "https://api.onthepixel.net/creators/followers";
+
+function formatFollowers(count: number) {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`;
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}K`;
+  return String(count);
+}
+
+/** Mirrors the server-side validation so the form can flag mistakes early. */
+function isValidUuid(value: string) {
+  return /^[0-9a-f]{32}$/i.test(value.trim().replace(/-/g, ""));
+}
+
+function Field({ label, hint, children }: { label: string; hint?: string; children: React.ReactNode }) {
   return (
-    <tr className="border-b border-white/5 transition-colors hover:bg-white/[0.02]">
-      <td className="py-3 pl-4 pr-3">
+    <div className="flex flex-col gap-1.5">
+      <label className="text-xs font-medium text-white/40">{label}</label>
+      {children}
+      {hint && <p className="text-[11px] text-white/25">{hint}</p>}
+    </div>
+  );
+}
+
+const inputClass =
+  "h-10 w-full rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-white/25 outline-none transition-colors focus:border-green-500/50 focus:ring-1 focus:ring-green-500/20";
+
+/* --- Channel editor: add, edit, reorder and remove a creator's channels --- */
+
+function ChannelEditor({
+  channels,
+  onChange,
+}: {
+  channels: Channel[];
+  onChange: (next: Channel[]) => void;
+}) {
+  const move = (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= channels.length) return;
+    const next = [...channels];
+    [next[index], next[target]] = [next[target], next[index]];
+    onChange(next);
+  };
+
+  const update = (index: number, patch: Partial<Channel>) => {
+    onChange(channels.map((c, i) => (i === index ? { ...c, ...patch } : c)));
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-center justify-between">
+        <label className="text-xs font-medium text-white/40">
+          Kanäle <span className="text-white/20">({channels.length})</span>
+        </label>
+        <button
+          type="button"
+          onClick={() => onChange([...channels, { platform: "youtube", url: "" }])}
+          className="flex items-center gap-1.5 rounded-lg bg-white/5 px-2.5 py-1.5 text-xs font-medium text-white/60 transition-colors hover:bg-white/10 hover:text-white"
+        >
+          <Plus size={13} /> Kanal
+        </button>
+      </div>
+
+      <p className="text-[11px] text-white/25">
+        Die Reihenfolge bestimmt die Anzeige auf der Website. Der{" "}
+        <span className="text-green-400/70">erste Kanal</span> ist der primäre: Follower-Zahl
+        und Live-Status werden über ihn ermittelt.
+      </p>
+
+      {channels.length === 0 ? (
+        <div className="flex flex-col items-center gap-2 rounded-xl border border-dashed border-white/10 py-6">
+          <LinkIcon size={20} className="text-white/15" />
+          <p className="text-xs text-white/30">Noch keine Kanäle hinterlegt.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {channels.map((channel, i) => (
+            <div
+              key={i}
+              className="flex items-center gap-2 rounded-xl border border-white/5 bg-white/[0.02] p-2"
+            >
+              <div className="flex flex-col">
+                <button
+                  type="button"
+                  onClick={() => move(i, -1)}
+                  disabled={i === 0}
+                  title="Nach oben"
+                  className="rounded p-0.5 text-white/30 transition-colors hover:text-white disabled:opacity-20 disabled:hover:text-white/30"
+                >
+                  <ChevronUp size={14} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => move(i, 1)}
+                  disabled={i === channels.length - 1}
+                  title="Nach unten"
+                  className="rounded p-0.5 text-white/30 transition-colors hover:text-white disabled:opacity-20 disabled:hover:text-white/30"
+                >
+                  <ChevronDown size={14} />
+                </button>
+              </div>
+
+              <GripVertical size={14} className="shrink-0 text-white/10" />
+
+              <div
+                className={`flex h-9 w-9 shrink-0 items-center justify-center rounded-lg text-base ${
+                  i === 0 ? "bg-green-500/10 ring-1 ring-green-500/30" : "bg-white/5"
+                }`}
+                title={i === 0 ? "Primärer Kanal (Follower & Live-Status)" : undefined}
+              >
+                {platformIcon(channel.platform)}
+              </div>
+
+              <select
+                value={channel.platform}
+                onChange={(e) => update(i, { platform: e.target.value })}
+                className="h-9 shrink-0 rounded-lg border border-white/10 bg-white/5 px-2 text-xs text-white outline-none focus:border-green-500/50"
+              >
+                {PLATFORMS.map((p) => (
+                  <option key={p.value} value={p.value} className="bg-gray-900">
+                    {p.label}
+                  </option>
+                ))}
+              </select>
+
+              <input
+                type="url"
+                value={channel.url}
+                onChange={(e) => update(i, { url: e.target.value })}
+                placeholder="https://…"
+                className="h-9 min-w-0 flex-1 rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white placeholder-white/25 outline-none focus:border-green-500/50"
+              />
+
+              <button
+                type="button"
+                onClick={() => onChange(channels.filter((_, idx) => idx !== i))}
+                title="Kanal entfernen"
+                className="shrink-0 rounded-lg p-2 text-white/30 transition-colors hover:bg-red-500/10 hover:text-red-400"
+              >
+                <Trash2 size={14} />
+              </button>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/* --- Create / edit modal --- */
+
+function CreatorModal({
+  draft,
+  onClose,
+  onSaved,
+}: {
+  draft: Draft;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const [form, setForm] = useState<Draft>(draft);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const editing = draft.id !== undefined;
+  const uuidTouched = form.minecraftUuid.trim().length > 0;
+  const uuidValid = isValidUuid(form.minecraftUuid);
+
+  const save = async () => {
+    if (!form.name.trim()) return setError("Name ist erforderlich.");
+    if (!uuidValid) return setError("Ungültige Minecraft-UUID.");
+
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch(
+        editing ? `/api/dashboard/creators/${draft.id}` : "/api/dashboard/creators",
+        {
+          method: editing ? "PATCH" : "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            name: form.name.trim(),
+            minecraftUuid: form.minecraftUuid.trim(),
+            channels: form.channels.filter((c) => c.url.trim()),
+          }),
+        },
+      );
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Fehler ${res.status}`);
+      onSaved();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto p-4 py-10">
+      <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-2xl rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <div className="mb-5 flex items-center justify-between">
+          <h2
+            className="text-lg font-bold text-white"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
+            {editing ? "Creator bearbeiten" : "Neuer Creator"}
+          </h2>
+          <button
+            onClick={onClose}
+            className="rounded-lg p-1.5 text-white/40 transition-colors hover:bg-white/5 hover:text-white"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {error && (
+          <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2.5 text-sm text-red-300">
+            <AlertCircle size={15} className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+
+        <div className="flex flex-col gap-4">
+          <div className="flex items-center gap-4">
+            <div className="h-16 w-16 shrink-0 overflow-hidden rounded-xl bg-white/5">
+              {uuidValid && (
+                <Image
+                  src={`https://api.mcskin.me/pfp/${form.minecraftUuid.trim()}`}
+                  alt={form.name || "Avatar"}
+                  width={64}
+                  height={64}
+                  className="h-16 w-16"
+                  unoptimized
+                />
+              )}
+            </div>
+            <div className="grid flex-1 gap-4 sm:grid-cols-2">
+              <Field label="Name">
+                <input
+                  type="text"
+                  value={form.name}
+                  onChange={(e) => setForm({ ...form, name: e.target.value })}
+                  placeholder="Creator-Name"
+                  className={inputClass}
+                />
+              </Field>
+              <Field
+                label="Minecraft-UUID"
+                hint={
+                  uuidTouched && !uuidValid
+                    ? "32 Hex-Zeichen, mit oder ohne Bindestriche."
+                    : undefined
+                }
+              >
+                <input
+                  type="text"
+                  value={form.minecraftUuid}
+                  onChange={(e) => setForm({ ...form, minecraftUuid: e.target.value })}
+                  placeholder="069a79f4-44e9-4726-a5be-fca90e38aaf5"
+                  className={`${inputClass} font-mono text-xs ${
+                    uuidTouched && !uuidValid ? "border-red-500/40" : ""
+                  }`}
+                />
+              </Field>
+            </div>
+          </div>
+
+          <ChannelEditor
+            channels={form.channels}
+            onChange={(channels) => setForm({ ...form, channels })}
+          />
+        </div>
+
+        <div className="mt-6 flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium text-white/50 transition-colors hover:bg-white/5 hover:text-white"
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={save}
+            disabled={saving}
+            className="flex items-center gap-2 rounded-xl bg-green-500 px-5 py-2.5 text-sm font-semibold text-black transition-colors hover:bg-green-400 disabled:opacity-60"
+          >
+            {saving ? <Loader2 size={15} className="animate-spin" /> : <Save size={15} />}
+            Speichern
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* --- Delete confirmation --- */
+
+function DeleteDialog({
+  creator,
+  onClose,
+  onDeleted,
+}: {
+  creator: Creator;
+  onClose: () => void;
+  onDeleted: () => void;
+}) {
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const remove = async () => {
+    setBusy(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/dashboard/creators/${creator.id}`, { method: "DELETE" });
+      if (!res.ok && res.status !== 204) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error ?? `Fehler ${res.status}`);
+      }
+      onDeleted();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="fixed inset-0 bg-black/70 backdrop-blur-sm" onClick={onClose} />
+      <div className="relative z-10 w-full max-w-md rounded-2xl border border-white/10 bg-gray-900 p-6 shadow-2xl">
+        <h2 className="text-lg font-bold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>
+          Creator löschen
+        </h2>
+        <p className="mt-2 text-sm text-white/50">
+          <span className="font-medium text-white">{creator.name}</span> und alle zugehörigen
+          Kanäle werden dauerhaft entfernt.
+        </p>
+        {error && (
+          <div className="mt-4 flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-3 py-2.5 text-sm text-red-300">
+            <AlertCircle size={15} className="mt-0.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+        <div className="mt-6 flex items-center justify-end gap-2">
+          <button
+            onClick={onClose}
+            className="rounded-xl px-4 py-2.5 text-sm font-medium text-white/50 transition-colors hover:bg-white/5 hover:text-white"
+          >
+            Abbrechen
+          </button>
+          <button
+            onClick={remove}
+            disabled={busy}
+            className="flex items-center gap-2 rounded-xl bg-red-500 px-5 py-2.5 text-sm font-semibold text-white transition-colors hover:bg-red-400 disabled:opacity-60"
+          >
+            {busy ? <Loader2 size={15} className="animate-spin" /> : <Trash2 size={15} />}
+            Löschen
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* --- Table row --- */
+
+function CreatorRow({
+  creator,
+  followers,
+  first,
+  last,
+  onMove,
+  onEdit,
+  onDelete,
+}: {
+  creator: Creator;
+  followers: number | null | undefined;
+  first: boolean;
+  last: boolean;
+  onMove: (direction: -1 | 1) => void;
+  onEdit: () => void;
+  onDelete: () => void;
+}) {
+  return (
+    <tr className="border-b border-white/5 transition-colors last:border-0 hover:bg-white/[0.02]">
+      <td className="py-3 pl-4 pr-2">
+        <div className="flex flex-col">
+          <button
+            onClick={() => onMove(-1)}
+            disabled={first}
+            title="Nach oben"
+            className="rounded p-0.5 text-white/25 transition-colors hover:text-white disabled:opacity-20 disabled:hover:text-white/25"
+          >
+            <ChevronUp size={14} />
+          </button>
+          <button
+            onClick={() => onMove(1)}
+            disabled={last}
+            title="Nach unten"
+            className="rounded p-0.5 text-white/25 transition-colors hover:text-white disabled:opacity-20 disabled:hover:text-white/25"
+          >
+            <ChevronDown size={14} />
+          </button>
+        </div>
+      </td>
+      <td className="py-3 pr-3">
         <div className="flex items-center gap-3">
           <Image
-            src={`https://api.mcskin.me/pfp/${creator.Minecraft_username}`}
-            alt={creator.Name}
+            src={`https://api.mcskin.me/pfp/${creator.minecraftUuid}`}
+            alt={creator.name}
             width={40}
             height={40}
             className="h-10 w-10 shrink-0 rounded-lg"
+            unoptimized
           />
           <div className="min-w-0">
-            <p className="truncate text-sm font-medium text-white">{creator.Name}</p>
-            <p className="truncate text-xs text-white/30">{creator.Minecraft_username}</p>
+            <p className="truncate text-sm font-medium text-white">{creator.name}</p>
+            <p className="truncate font-mono text-[11px] text-white/25">
+              {creator.minecraftUuid}
+            </p>
           </div>
         </div>
       </td>
       <td className="px-3 py-3">
         <div className="flex flex-wrap gap-1.5">
-          {(creator.Platforms ?? []).map((p, i) => (
-            <PlatformBadge key={i} platform={p} />
+          {creator.channels.map((channel, i) => (
+            <a
+              key={i}
+              href={channel.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              title={i === 0 ? `${channel.url} — primärer Kanal` : channel.url}
+              className={`inline-flex items-center gap-1.5 rounded-md px-2 py-1 text-xs transition-colors hover:bg-white/10 hover:text-white ${
+                i === 0
+                  ? "bg-green-500/10 text-white/80 ring-1 ring-green-500/25"
+                  : "bg-white/5 text-white/60"
+              }`}
+            >
+              {platformIcon(channel.platform)}
+              {platformLabel(channel.platform)}
+            </a>
           ))}
-          {(!creator.Platforms || creator.Platforms.length === 0) && (
-            <span className="text-xs text-white/20">No platforms</span>
+          {creator.channels.length === 0 && (
+            <span className="text-xs text-white/20">Keine Kanäle</span>
           )}
         </div>
       </td>
+      <td className="px-3 py-3 text-right">
+        {followers === undefined ? (
+          <Loader2 size={13} className="ml-auto animate-spin text-white/15" />
+        ) : followers === null ? (
+          <span className="text-xs text-white/15">—</span>
+        ) : (
+          <span className="text-sm font-medium text-white/70">
+            {formatFollowers(followers)}
+          </span>
+        )}
+      </td>
       <td className="py-3 pl-3 pr-4">
-        <a
-          href={`/creators`}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-white/40 transition-colors hover:bg-white/5 hover:text-white"
-        >
-          <ExternalLink size={12} /> View
-        </a>
+        <div className="flex items-center justify-end gap-1">
+          <button
+            onClick={onEdit}
+            title="Bearbeiten"
+            className="rounded-lg p-2 text-white/30 transition-colors hover:bg-white/5 hover:text-white"
+          >
+            <Pencil size={14} />
+          </button>
+          <button
+            onClick={onDelete}
+            title="Löschen"
+            className="rounded-lg p-2 text-white/30 transition-colors hover:bg-red-500/10 hover:text-red-400"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
       </td>
     </tr>
   );
 }
 
+/* --- Page --- */
+
 function CreatorsDashboardContent() {
   const [creators, setCreators] = useState<Creator[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const [search, setSearch] = useState("");
+  const [draft, setDraft] = useState<Draft | null>(null);
+  const [deleting, setDeleting] = useState<Creator | null>(null);
+  const [followers, setFollowers] = useState<Record<number, number | null>>({});
 
-  const loadCreators = useCallback(async () => {
+  const load = useCallback(async () => {
     setLoading(true);
+    setError(null);
     try {
-      const res = await fetch(
-        "https://cms.onthepixel.net/items/Creators?fields=*.*.*&limit=200"
-      );
-      if (!res.ok) throw new Error("Failed to fetch");
-      const data = await res.json();
-      setCreators(data.data ?? []);
-    } catch {
+      const res = await fetch("/api/dashboard/creators");
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Fehler ${res.status}`);
+      setCreators(body.data ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
       setCreators([]);
     } finally {
       setLoading(false);
@@ -111,27 +589,85 @@ function CreatorsDashboardContent() {
   }, []);
 
   useEffect(() => {
-    loadCreators();
-  }, [loadCreators]);
+    load();
+  }, [load]);
 
-  const filtered = creators.filter(
-    (c) =>
-      c.Name.toLowerCase().includes(search.toLowerCase()) ||
-      c.Minecraft_username.toLowerCase().includes(search.toLowerCase())
-  );
+  // Follower counts are pulled per creator from the stats service; a failure
+  // there must not affect the management view, so each lookup fails to `null`.
+  useEffect(() => {
+    if (creators.length === 0) return;
+    let cancelled = false;
+
+    (async () => {
+      const entries = await Promise.all(
+        creators.map(async (creator) => {
+          try {
+            const res = await fetch(`${FOLLOWERS_API}/${encodeURIComponent(creator.name)}`);
+            if (!res.ok) return [creator.id, null] as const;
+            const body = await res.json();
+            const social = body?.data?.social;
+            const count = social?.followers ?? social?.subscribers ?? null;
+            return [creator.id, typeof count === "number" ? count : null] as const;
+          } catch {
+            return [creator.id, null] as const;
+          }
+        }),
+      );
+      if (!cancelled) setFollowers(Object.fromEntries(entries));
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [creators]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return creators;
+    return creators.filter(
+      (c) =>
+        c.name.toLowerCase().includes(q) ||
+        c.minecraftUuid.toLowerCase().includes(q) ||
+        c.channels.some((ch) => ch.platform.toLowerCase().includes(q)),
+    );
+  }, [creators, search]);
+
+  /**
+   * Reordering acts on the unfiltered list, so it is only offered while no
+   * search is active — otherwise "one row up" would not match what is on screen.
+   */
+  const reorderable = search.trim().length === 0;
+
+  const move = async (index: number, direction: -1 | 1) => {
+    const target = index + direction;
+    if (target < 0 || target >= creators.length) return;
+    const next = [...creators];
+    [next[index], next[target]] = [next[target], next[index]];
+    setCreators(next);
+    try {
+      const res = await fetch("/api/dashboard/creators/order", {
+        method: "PUT",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ ids: next.map((c) => c.id) }),
+      });
+      if (!res.ok) throw new Error(`Fehler ${res.status}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      load();
+    }
+  };
+
+  const channelCount = creators.reduce((sum, c) => sum + c.channels.length, 0);
 
   return (
     <div>
       <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
         <div>
-          <h1
-            className="text-2xl font-bold text-white"
-            style={{ fontFamily: "'Syne', sans-serif" }}
-          >
+          <h1 className="text-2xl font-bold text-white" style={{ fontFamily: "'Syne', sans-serif" }}>
             Creators
           </h1>
           <p className="mt-0.5 text-sm text-white/40">
-            {creators.length} creators total
+            {creators.length} Creator · {channelCount} Kanäle
           </p>
         </div>
 
@@ -143,58 +679,126 @@ function CreatorsDashboardContent() {
             />
             <input
               type="text"
-              placeholder="Search creators..."
+              placeholder="Suchen…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="h-9 w-full rounded-lg border border-white/10 bg-white/5 pl-9 pr-4 text-sm text-white placeholder-white/30 outline-none focus:border-blue-500/50 focus:ring-1 focus:ring-blue-500/20 sm:w-64"
+              className="h-9 w-full rounded-lg border border-white/10 bg-white/5 pl-9 pr-4 text-sm text-white placeholder-white/30 outline-none focus:border-green-500/50 focus:ring-1 focus:ring-green-500/20 sm:w-56"
             />
           </div>
           <button
-            onClick={loadCreators}
+            onClick={load}
             disabled={loading}
+            title="Neu laden"
             className="flex h-9 items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-50"
           >
             <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
-            Refresh
+          </button>
+          <button
+            onClick={() => setDraft({ ...EMPTY_DRAFT })}
+            className="flex h-9 items-center gap-2 rounded-lg bg-green-500 px-4 text-sm font-semibold text-black transition-colors hover:bg-green-400"
+          >
+            <Plus size={15} /> Creator
           </button>
         </div>
       </div>
 
-      <div className="overflow-hidden rounded-xl border border-white/5 bg-white/[0.02]">
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      <div className="overflow-hidden rounded-2xl border border-white/5 bg-white/[0.02]">
         {loading ? (
           <div className="flex items-center justify-center py-16">
-            <div className="h-8 w-8 animate-spin rounded-full border-2 border-blue-400 border-t-transparent" />
+            <div className="h-8 w-8 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
           </div>
         ) : filtered.length === 0 ? (
           <div className="flex flex-col items-center justify-center gap-3 py-16">
             <Users size={32} className="text-white/10" />
-            <p className="text-sm text-white/30">No creators found.</p>
+            <p className="text-sm text-white/30">
+              {creators.length === 0 ? "Noch keine Creator angelegt." : "Keine Treffer."}
+            </p>
+            {creators.length === 0 && (
+              <button
+                onClick={() => setDraft({ ...EMPTY_DRAFT })}
+                className="flex items-center gap-2 rounded-lg bg-green-500/10 px-4 py-2 text-sm font-medium text-green-400 transition-colors hover:bg-green-500/20"
+              >
+                <Plus size={15} /> Ersten Creator anlegen
+              </button>
+            )}
           </div>
         ) : (
           <div className="overflow-x-auto">
-            <table className="w-full min-w-[640px]">
+            <table className="w-full min-w-[720px]">
               <thead>
                 <tr className="border-b border-white/5">
-                  <th className="py-3 pl-4 pr-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">
+                  <th className="w-10 py-3 pl-4 pr-2" />
+                  <th className="py-3 pr-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">
                     Creator
                   </th>
                   <th className="px-3 py-3 text-left text-xs font-medium uppercase tracking-wider text-white/30">
-                    Platforms
+                    Kanäle
                   </th>
-                  <th className="py-3 pl-3 pr-4 text-left text-xs font-medium uppercase tracking-wider text-white/30">
-                    Actions
+                  <th className="px-3 py-3 text-right text-xs font-medium uppercase tracking-wider text-white/30">
+                    Follower
+                  </th>
+                  <th className="py-3 pl-3 pr-4 text-right text-xs font-medium uppercase tracking-wider text-white/30">
+                    Aktionen
                   </th>
                 </tr>
               </thead>
               <tbody>
-                {filtered.map((creator, i) => (
-                  <CreatorRow key={i} creator={creator} />
-                ))}
+                {filtered.map((creator) => {
+                  const index = creators.indexOf(creator);
+                  return (
+                    <CreatorRow
+                      key={creator.id}
+                      creator={creator}
+                      followers={followers[creator.id]}
+                      first={!reorderable || index === 0}
+                      last={!reorderable || index === creators.length - 1}
+                      onMove={(direction) => move(index, direction)}
+                      onEdit={() =>
+                        setDraft({
+                          id: creator.id,
+                          name: creator.name,
+                          minecraftUuid: creator.minecraftUuid,
+                          channels: creator.channels.map((c) => ({ ...c })),
+                        })
+                      }
+                      onDelete={() => setDeleting(creator)}
+                    />
+                  );
+                })}
               </tbody>
             </table>
           </div>
         )}
       </div>
+
+      {draft && (
+        <CreatorModal
+          draft={draft}
+          onClose={() => setDraft(null)}
+          onSaved={() => {
+            setDraft(null);
+            load();
+          }}
+        />
+      )}
+
+      {deleting && (
+        <DeleteDialog
+          creator={deleting}
+          onClose={() => setDeleting(null)}
+          onDeleted={() => {
+            setDeleting(null);
+            load();
+          }}
+        />
+      )}
     </div>
   );
 }

--- a/src/app/dashboard/overview.tsx
+++ b/src/app/dashboard/overview.tsx
@@ -75,20 +75,17 @@ function OverviewContent() {
       try {
         const [newsRes, creatorsRes, teamRes] = await Promise.all([
           fetch("/api/dashboard/news"),
-          fetch(
-            "https://cms.onthepixel.net/items/Creators?limit=1&meta=total_count",
-          ),
+          fetch("/api/dashboard/creators"),
           fetch("/api/dashboard/team"),
         ]);
         const [newsData, creatorsData, teamData] = await Promise.all([
           newsRes.ok ? newsRes.json() : Promise.resolve({ data: [] }),
-          creatorsRes.json(),
+          creatorsRes.ok ? creatorsRes.json() : Promise.resolve({ data: [] }),
           teamRes.ok ? teamRes.json() : Promise.resolve({ users: [] }),
         ]);
         setStats({
           newsCount: newsData?.data?.length ?? 0,
-          creatorsCount:
-            creatorsData?.meta?.total_count ?? creatorsData?.data?.length ?? 0,
+          creatorsCount: creatorsData?.data?.length ?? 0,
           teamCount: teamData?.users?.length ?? 0,
           loading: false,
         });

--- a/src/lib/creators.ts
+++ b/src/lib/creators.ts
@@ -1,0 +1,130 @@
+import { asc } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { ensureCreatorTables } from "@/lib/db/migrate";
+
+/**
+ * Platform keys understood by the icon mapping in `components/page/creators.tsx`
+ * and by the dashboard's channel editor. Keep both in sync when adding one.
+ */
+export const CHANNEL_PLATFORMS = [
+  "youtube",
+  "twitch",
+  "tiktok",
+  "instagram",
+  "x_twitter",
+  "discord",
+  "whatsapp",
+  "website",
+] as const;
+
+export type ChannelPlatform = (typeof CHANNEL_PLATFORMS)[number];
+
+/** A channel as stored and edited in the dashboard. */
+export interface CreatorChannel {
+  id?: number;
+  platform: string;
+  url: string;
+}
+
+/** A creator as returned by the dashboard API. */
+export interface CreatorEntry {
+  id: number;
+  name: string;
+  minecraftUuid: string;
+  sortOrder: number;
+  channels: CreatorChannel[];
+}
+
+/**
+ * The shape the public site consumes. It mirrors the legacy Directus payload
+ * (`Minecraft_username` / `Name` / `Platforms`) so the existing components keep
+ * working unchanged; `Minecraft_username` carries the Minecraft UUID, which the
+ * avatar service accepts just like a name.
+ */
+export interface PublicCreator {
+  Minecraft_username: string;
+  Name: string;
+  Platforms: { Icons: string; Link: string }[];
+}
+
+/**
+ * Accept a Minecraft UUID with or without dashes and return it in the canonical
+ * dashed lower-case form, or `null` when it is not a valid UUID.
+ */
+export function normalizeMinecraftUuid(input: unknown): string | null {
+  const raw = String(input ?? "").trim().toLowerCase().replace(/-/g, "");
+  if (!/^[0-9a-f]{32}$/.test(raw)) return null;
+  return [
+    raw.slice(0, 8),
+    raw.slice(8, 12),
+    raw.slice(12, 16),
+    raw.slice(16, 20),
+    raw.slice(20),
+  ].join("-");
+}
+
+/**
+ * Normalise the channel list coming from the dashboard: keep the submitted
+ * order (that order is what gets persisted as `sort_order`), trim the values
+ * and drop entries without a usable http(s) link.
+ */
+export function sanitizeChannels(input: unknown): CreatorChannel[] {
+  if (!Array.isArray(input)) return [];
+  return input
+    .map((raw) => {
+      const entry = raw as { platform?: unknown; url?: unknown };
+      return {
+        platform: String(entry?.platform ?? "").trim().toLowerCase() || "website",
+        url: String(entry?.url ?? "").trim(),
+      };
+    })
+    .filter((c) => /^https?:\/\/\S+$/i.test(c.url));
+}
+
+/** Read every creator with its channels, ordered by the configured sort order. */
+export async function listCreators(): Promise<CreatorEntry[]> {
+  await ensureCreatorTables();
+  const db = getDb();
+
+  const [rows, channels] = await Promise.all([
+    db
+      .select()
+      .from(schema.creators)
+      .orderBy(asc(schema.creators.sort_order), asc(schema.creators.id)),
+    db
+      .select()
+      .from(schema.creatorChannels)
+      .orderBy(asc(schema.creatorChannels.sort_order), asc(schema.creatorChannels.id)),
+  ]);
+
+  return rows.map((row) => ({
+    id: row.id,
+    name: row.name,
+    minecraftUuid: row.minecraft_uuid,
+    sortOrder: row.sort_order,
+    channels: channels
+      .filter((c) => c.creator_id === row.id)
+      .map((c) => ({ id: c.id, platform: c.platform, url: c.url })),
+  }));
+}
+
+export function toPublicCreator(entry: CreatorEntry): PublicCreator {
+  return {
+    Minecraft_username: entry.minecraftUuid,
+    Name: entry.name,
+    Platforms: entry.channels.map((c) => ({ Icons: c.platform, Link: c.url })),
+  };
+}
+
+/**
+ * Creators in the public payload shape. Returns an empty list when the database
+ * is unreachable or not seeded yet so callers can fall back to the CMS.
+ */
+export async function getPublicCreators(): Promise<PublicCreator[]> {
+  try {
+    return (await listCreators()).map(toPublicCreator);
+  } catch (e) {
+    console.error("[creators] database read failed:", e);
+    return [];
+  }
+}

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -2,6 +2,7 @@ import { getDb } from "./index";
 import { sql } from "drizzle-orm";
 
 let initialized = false;
+let creatorsInitialized = false;
 
 export async function ensureTable() {
   if (initialized) return;
@@ -38,6 +39,40 @@ export async function ensureTable() {
     initialized = true;
   } catch (e) {
     console.error("[db] ensureTable failed:", e);
+    throw e;
+  }
+}
+
+export async function ensureCreatorTables() {
+  if (creatorsInitialized) return;
+  const db = getDb();
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS creators (
+        id SERIAL PRIMARY KEY,
+        minecraft_uuid TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS creator_channels (
+        id SERIAL PRIMARY KEY,
+        creator_id INTEGER NOT NULL REFERENCES creators(id) ON DELETE CASCADE,
+        platform TEXT NOT NULL,
+        url TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0
+      )
+    `);
+    await db.execute(sql`
+      CREATE INDEX IF NOT EXISTS creator_channels_creator_id_idx
+        ON creator_channels (creator_id, sort_order)
+    `);
+    creatorsInitialized = true;
+  } catch (e) {
+    console.error("[db] ensureCreatorTables failed:", e);
     throw e;
   }
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -22,6 +22,26 @@ export const newsTranslations = pgTable("news_translations", {
   content: text("content").notNull().default(""),
 });
 
+export const creators = pgTable("creators", {
+  id: serial("id").primaryKey(),
+  minecraft_uuid: text("minecraft_uuid").notNull().unique(),
+  name: text("name").notNull(),
+  sort_order: integer("sort_order").notNull().default(0),
+  created_at: timestamp("created_at", { withTimezone: true }).defaultNow().notNull(),
+  updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
+export const creatorChannels = pgTable("creator_channels", {
+  id: serial("id").primaryKey(),
+  creator_id: integer("creator_id").notNull().references(() => creators.id, { onDelete: "cascade" }),
+  platform: text("platform").notNull(),
+  url: text("url").notNull(),
+  sort_order: integer("sort_order").notNull().default(0),
+});
+
 export type NewsItem = typeof news.$inferSelect;
 export type NewNewsItem = typeof news.$inferInsert;
 export type NewsTranslationItem = typeof newsTranslations.$inferSelect;
+export type CreatorRecord = typeof creators.$inferSelect;
+export type NewCreatorRecord = typeof creators.$inferInsert;
+export type CreatorChannelRecord = typeof creatorChannels.$inferSelect;


### PR DESCRIPTION
Creators wurden bisher schreibgeschützt aus dem Directus-CMS gelesen. Sie werden jetzt in Postgres gehalten und im Admin-Dashboard vollständig verwaltet — für Creators wird das CMS nicht mehr angefragt.

## Datenmodell

| Tabelle | Spalten |
| --- | --- |
| `creators` | `id`, `minecraft_uuid` (unique), `name`, `sort_order`, `created_at`, `updated_at` |
| `creator_channels` | `id`, `creator_id` (FK, `ON DELETE CASCADE`), `platform`, `url`, `sort_order` |

Die Tabellen werden wie bei den News beim ersten Zugriff über `ensureCreatorTables()` angelegt — es reicht, `DATABASE_URL` auf den neuen Postgres-User zu setzen, es ist kein manueller Migrationsschritt nötig.

## Dashboard (`/dashboard/creators`)

- Creators anlegen, bearbeiten und löschen
- Kanal-Editor: Plattform auswählen, URL setzen, Kanäle per Pfeiltasten sortieren und entfernen
- Der **erste Kanal ist der primäre** und ist im Editor sowie in der Tabelle markiert — Follower-Zahl und Live-Status werden über ihn ermittelt
- Creator-Reihenfolge per Pfeiltasten (bestimmt die Reihenfolge auf `/creators`)
- Suche über Name, UUID und Plattform
- Follower-Zahl je Creator aus dem Stats-Service; schlägt der Abruf fehl, bleibt die Verwaltung davon unberührt

## REST-API

Öffentlich, ohne Auth:

| Request | Ergebnis |
| --- | --- |
| `GET /api/creators` | alle Creators |
| `GET /api/creators?uuid=<uuid>` | einzelner Creator (UUID mit oder ohne Bindestriche) |
| `GET /api/creators?name=<name>` | einzelner Creator (case-insensitive) |
| `GET /api/creators?limit=&offset=` | Pagination |
| `GET /api/creators?format=raw` | interne Feldnamen statt CMS-Format |

Das Standard-Format entspricht exakt dem bisherigen CMS-Payload (`Minecraft_username` / `Name` / `Platforms[].{Icons, Link}`), damit bestehende Consumer unverändert weiterlaufen — `Minecraft_username` enthält jetzt die Minecraft-UUID.

Auth-geschützt (Dashboard):

| Request | Ergebnis |
| --- | --- |
| `GET/POST /api/dashboard/creators` | auflisten / anlegen |
| `PATCH/DELETE /api/dashboard/creators/:id` | ändern / löschen |
| `PUT /api/dashboard/creators/order` | Reihenfolge speichern |

## Weitere Änderungen

- `/creators` liest die Creators aus Postgres statt aus dem CMS
- Die Creator-Zahl auf der Dashboard-Übersicht kommt aus der neuen API statt aus dem CMS
- Minecraft-UUIDs werden mit und ohne Bindestriche akzeptiert und kanonisch gespeichert; doppelte UUIDs werden über den SQLSTATE `23505` der Cause erkannt und als `409` gemeldet (die Meldung von drizzle/postgres.js selbst enthält nur den Query-Text)
- Kanal-URLs ohne `http(s)`-Schema werden serverseitig verworfen

## Tests

Gegen eine lokale Postgres-Instanz geprüft:

- Tabellen inkl. Unique-Constraint, Fremdschlüssel und Index werden korrekt angelegt
- Sortierung von Creators und Kanälen wird eingehalten (`sort_order`)
- Lookup per UUID (mit/ohne Bindestriche) und per Name, `format=raw`, 404 bei unbekanntem Creator
- Anlegen vergibt fortlaufende `sort_order`; doppelte UUID wird abgewiesen und auf die 409-Meldung gemappt
- Kanäle werden beim Bearbeiten vollständig ersetzt, ohne Duplikate, mit neuer Reihenfolge
- Löschen entfernt die Kanäle per Cascade

`npm run typecheck` und `npm run build` laufen sauber durch. `npm run lint` ist im Repo bereits vor dieser Änderung defekt (`next lint` wurde in Next 16 entfernt, und die vorhandene `.eslintrc.json` wird von ESLint 10 nicht mehr gelesen) — hier nicht angefasst.

## Offen

Das CMS wird weiterhin von `/sidequests` und den `/apply`-Seiten verwendet. Diese Inhalte sind hier nicht migriert und müssten separat umgezogen werden, bevor das CMS ganz abgeschaltet werden kann.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vqoSTpv1rPPqC6qgCaFWB)_