### PR TITLE
Bewerbungsstatus im Dashboard verwalten + Creator-Import aus dem CMS

### DIFF
--- a/scripts/import-creators.mjs
+++ b/scripts/import-creators.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * Importiert die Creators aus dem Directus-CMS in Postgres.
+ *
+ *   DATABASE_URL=postgres://… node scripts/import-creators.mjs           # Dry-Run
+ *   DATABASE_URL=postgres://… node scripts/import-creators.mjs --write   # schreibt
+ *
+ * Das CMS speichert unter `Minecraft_username` einen Spielernamen, die neue
+ * Tabelle braucht aber eine UUID — die Namen werden deshalb ueber die
+ * Mojang-API aufgeloest (gebuendelt, 10 Namen pro Anfrage).
+ *
+ * Der Import ist wiederholbar: bereits vorhandene Creators (gleiche UUID)
+ * werden aktualisiert statt doppelt angelegt, die Kanaele werden dabei
+ * vollstaendig ersetzt. Die Reihenfolge der Platforms aus dem CMS bleibt
+ * erhalten — Platform[0] ist weiterhin der primaere Kanal.
+ *
+ * Optionen:
+ *   --write            Aenderungen wirklich schreiben (ohne: nur Vorschau)
+ *   --cms-url=<url>    abweichende CMS-Collection
+ *   --skip-existing    vorhandene Creators unveraendert lassen
+ */
+
+import postgres from "postgres";
+
+const args = process.argv.slice(2);
+const hasFlag = (name) => args.includes(name);
+const getOpt = (name, fallback) => {
+  const hit = args.find((a) => a.startsWith(`${name}=`));
+  return hit ? hit.slice(name.length + 1) : fallback;
+};
+
+const WRITE = hasFlag("--write");
+const SKIP_EXISTING = hasFlag("--skip-existing");
+const CMS_URL = getOpt(
+  "--cms-url",
+  "https://cms.onthepixel.net/items/Creators?fields=*.*.*&limit=-1",
+);
+
+const DATABASE_URL = process.env.DATABASE_URL;
+if (!DATABASE_URL) {
+  console.error("DATABASE_URL ist nicht gesetzt.");
+  process.exit(1);
+}
+
+const UUID_RE = /^[0-9a-f]{32}$/i;
+
+function dashUuid(raw) {
+  const hex = String(raw).replace(/-/g, "").toLowerCase();
+  if (!UUID_RE.test(hex)) return null;
+  return [
+    hex.slice(0, 8),
+    hex.slice(8, 12),
+    hex.slice(12, 16),
+    hex.slice(16, 20),
+    hex.slice(20),
+  ].join("-");
+}
+
+/** Namen -> UUID ueber die Mojang-Bulk-API (max. 10 Namen pro Anfrage). */
+async function resolveUuids(names) {
+  const resolved = new Map();
+
+  for (let i = 0; i < names.length; i += 10) {
+    const batch = names.slice(i, i + 10);
+    try {
+      const res = await fetch(
+        "https://api.minecraftservices.com/minecraft/profile/lookup/bulk/byname",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(batch),
+        },
+      );
+      if (!res.ok) {
+        console.warn(`  ! Mojang-Bulk-Lookup fehlgeschlagen (${res.status}), einzeln…`);
+        for (const name of batch) {
+          const single = await fetch(
+            `https://api.mojang.com/users/profiles/minecraft/${encodeURIComponent(name)}`,
+          );
+          if (single.ok) {
+            const profile = await single.json();
+            if (profile?.id) resolved.set(name.toLowerCase(), dashUuid(profile.id));
+          }
+        }
+        continue;
+      }
+      for (const profile of await res.json()) {
+        if (profile?.id && profile?.name)
+          resolved.set(profile.name.toLowerCase(), dashUuid(profile.id));
+      }
+    } catch (e) {
+      console.warn(`  ! Lookup-Fehler fuer ${batch.join(", ")}: ${e.message}`);
+    }
+  }
+
+  return resolved;
+}
+
+async function main() {
+  console.log(`CMS  : ${CMS_URL}`);
+  console.log(`Modus: ${WRITE ? "SCHREIBEN" : "Dry-Run (nichts wird gespeichert)"}\n`);
+
+  const res = await fetch(CMS_URL);
+  if (!res.ok) throw new Error(`CMS antwortet mit ${res.status}`);
+  const creators = (await res.json())?.data ?? [];
+  console.log(`${creators.length} Creators im CMS gefunden.\n`);
+  if (creators.length === 0) return;
+
+  // Namen, die noch aufgeloest werden muessen (im CMS koennen auch schon
+  // UUIDs stehen — die werden direkt uebernommen).
+  const needsLookup = creators
+    .map((c) => String(c.Minecraft_username ?? "").trim())
+    .filter((v) => v && !dashUuid(v));
+
+  const uuidByName = needsLookup.length
+    ? await resolveUuids([...new Set(needsLookup)])
+    : new Map();
+
+  // `onnotice` stumm schalten, sonst druckt postgres.js bei jedem Lauf die
+  // "relation already exists, skipping"-Hinweise von CREATE TABLE IF NOT EXISTS.
+  const sql = postgres(DATABASE_URL, { ssl: false, max: 1, onnotice: () => {} });
+
+  // Tabellen anlegen, falls das Dashboard noch nicht aufgerufen wurde.
+  if (WRITE) {
+    await sql`
+      CREATE TABLE IF NOT EXISTS creators (
+        id SERIAL PRIMARY KEY,
+        minecraft_uuid TEXT NOT NULL UNIQUE,
+        name TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )`;
+    await sql`
+      CREATE TABLE IF NOT EXISTS creator_channels (
+        id SERIAL PRIMARY KEY,
+        creator_id INTEGER NOT NULL REFERENCES creators(id) ON DELETE CASCADE,
+        platform TEXT NOT NULL,
+        url TEXT NOT NULL,
+        sort_order INTEGER NOT NULL DEFAULT 0
+      )`;
+    await sql`
+      CREATE INDEX IF NOT EXISTS creator_channels_creator_id_idx
+        ON creator_channels (creator_id, sort_order)`;
+  }
+
+  // Im Dry-Run kann die Tabelle noch fehlen — dann gibt es auch nichts
+  // abzufragen, und der Lauf zeigt einfach alle Creators als "neu".
+  const [{ exists }] = await sql`
+    SELECT to_regclass('public.creators') IS NOT NULL AS exists`;
+
+  let nextOrder = 0;
+  if (exists) {
+    const [{ max }] = await sql`
+      SELECT COALESCE(MAX(sort_order), -1) AS max FROM creators`;
+    nextOrder = Number(max) + 1;
+  }
+
+  let created = 0;
+  let updated = 0;
+  let skipped = 0;
+
+  for (const creator of creators) {
+    const name = String(creator.Name ?? "").trim();
+    const rawId = String(creator.Minecraft_username ?? "").trim();
+    const uuid = dashUuid(rawId) ?? uuidByName.get(rawId.toLowerCase()) ?? null;
+
+    if (!name || !uuid) {
+      console.log(`  ÜBERSPRUNGEN  ${name || "(ohne Name)"} — keine UUID fuer "${rawId}"`);
+      skipped++;
+      continue;
+    }
+
+    const channels = (creator.Platforms ?? [])
+      .map((p) => ({
+        platform: String(p?.Icons ?? "").trim().toLowerCase() || "website",
+        url: String(p?.Link ?? "").trim(),
+      }))
+      .filter((c) => /^https?:\/\/\S+$/i.test(c.url));
+
+    const [existing] = exists
+      ? await sql`SELECT id FROM creators WHERE minecraft_uuid = ${uuid} LIMIT 1`
+      : [];
+
+    if (existing && SKIP_EXISTING) {
+      console.log(`  UNVERAENDERT  ${name}`);
+      skipped++;
+      continue;
+    }
+
+    const action = existing ? "AKTUALISIERT " : "NEU         ";
+    console.log(
+      `  ${action}  ${name.padEnd(20)} ${uuid}  ${channels.length} Kanal/Kanaele` +
+        (channels.length ? ` (primaer: ${channels[0].platform})` : ""),
+    );
+
+    if (!WRITE) {
+      existing ? updated++ : created++;
+      continue;
+    }
+
+    let creatorId;
+    if (existing) {
+      creatorId = existing.id;
+      await sql`
+        UPDATE creators SET name = ${name}, updated_at = NOW() WHERE id = ${creatorId}`;
+      await sql`DELETE FROM creator_channels WHERE creator_id = ${creatorId}`;
+      updated++;
+    } else {
+      const [row] = await sql`
+        INSERT INTO creators (minecraft_uuid, name, sort_order)
+        VALUES (${uuid}, ${name}, ${nextOrder++})
+        RETURNING id`;
+      creatorId = row.id;
+      created++;
+    }
+
+    for (let i = 0; i < channels.length; i++) {
+      await sql`
+        INSERT INTO creator_channels (creator_id, platform, url, sort_order)
+        VALUES (${creatorId}, ${channels[i].platform}, ${channels[i].url}, ${i})`;
+    }
+  }
+
+  console.log(
+    `\n${WRITE ? "Fertig" : "Vorschau"}: ${created} neu, ${updated} aktualisiert, ${skipped} uebersprungen.`,
+  );
+  if (!WRITE) console.log("Zum Schreiben nochmal mit --write starten.");
+
+  await sql.end();
+}
+
+main().catch((e) => {
+  console.error(`\nFehlgeschlagen: ${e.message}`);
+  process.exit(1);
+});

--- a/src/app/api/apply/route.ts
+++ b/src/app/api/apply/route.ts
@@ -1,0 +1,59 @@
+import { NextRequest, NextResponse } from "next/server";
+import { listApplyPositions } from "@/lib/apply";
+
+const CORS = { "Access-Control-Allow-Origin": "*" };
+
+/**
+ * Public read-only REST API for the apply positions.
+ *
+ *   GET /api/apply              → all positions
+ *   GET /api/apply?slug=builder → a single position
+ *
+ * The payload keeps the field names of the legacy CMS collection
+ * (`id` / `name` / `status`) so existing consumers keep working; `slug` is
+ * added on top.
+ */
+export async function GET(req: NextRequest) {
+  const slug = req.nextUrl.searchParams.get("slug");
+
+  try {
+    const positions = await listApplyPositions();
+
+    if (slug) {
+      const position = positions.find(
+        (p) => p.slug.toLowerCase() === slug.trim().toLowerCase(),
+      );
+      if (!position)
+        return NextResponse.json(
+          { error: "Not found" },
+          { status: 404, headers: CORS },
+        );
+      return NextResponse.json(
+        { data: position },
+        {
+          headers: {
+            ...CORS,
+            "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
+          },
+        },
+      );
+    }
+
+    return NextResponse.json(
+      { data: positions },
+      {
+        headers: {
+          ...CORS,
+          "Cache-Control": "public, s-maxage=30, stale-while-revalidate=120",
+        },
+      },
+    );
+  } catch (e) {
+    console.error("[apply public GET]", e);
+    return NextResponse.json({ error: String(e) }, { status: 500, headers: CORS });
+  }
+}
+
+export function OPTIONS() {
+  return new NextResponse(null, { status: 204, headers: CORS });
+}

--- a/src/app/api/dashboard/apply/route.ts
+++ b/src/app/api/dashboard/apply/route.ts
@@ -1,0 +1,76 @@
+import { NextRequest, NextResponse } from "next/server";
+import { auth } from "@/auth";
+import { getDb, schema } from "@/lib/db";
+import { ensureApplyTables } from "@/lib/db/migrate";
+import { listApplyPositions } from "@/lib/apply";
+import { eq } from "drizzle-orm";
+
+async function checkAuth() {
+  const session = await auth();
+  return !!session;
+}
+
+/** GET — list the apply positions with their open/closed status. */
+export async function GET() {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  try {
+    await ensureApplyTables();
+    return NextResponse.json({ data: await listApplyPositions() });
+  } catch (e) {
+    console.error("[apply GET]", e);
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}
+
+/** PATCH — open or close a position, addressed by id or slug. */
+export async function PATCH(req: NextRequest) {
+  if (!(await checkAuth()))
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  try {
+    await ensureApplyTables();
+    const body = await req.json();
+
+    const status = String(body.status ?? "");
+    if (status !== "open" && status !== "closed")
+      return NextResponse.json(
+        { error: "status muss 'open' oder 'closed' sein." },
+        { status: 400 },
+      );
+
+    const id = body.id !== undefined ? Number(body.id) : null;
+    const slug = body.slug !== undefined ? String(body.slug).trim() : null;
+    if (id === null && !slug)
+      return NextResponse.json(
+        { error: "id oder slug ist erforderlich." },
+        { status: 400 },
+      );
+
+    const [updated] = await getDb()
+      .update(schema.applyPositions)
+      .set({ status, updated_at: new Date() })
+      .where(
+        id !== null
+          ? eq(schema.applyPositions.id, id)
+          : eq(schema.applyPositions.slug, slug!),
+      )
+      .returning();
+
+    if (!updated)
+      return NextResponse.json({ error: "Not found" }, { status: 404 });
+
+    return NextResponse.json({
+      data: {
+        id: updated.id,
+        name: updated.name,
+        slug: updated.slug,
+        status: updated.status,
+        sortOrder: updated.sort_order,
+      },
+    });
+  } catch (e) {
+    console.error("[apply PATCH]", e);
+    return NextResponse.json({ error: String(e) }, { status: 500 });
+  }
+}

--- a/src/app/apply/api/[position]/route.ts
+++ b/src/app/apply/api/[position]/route.ts
@@ -1,5 +1,6 @@
 import { auth } from "@/auth";
 import { NextRequest, NextResponse } from "next/server";
+import { isPositionOpen } from "@/lib/apply";
 
 const POSITION_NAMES: Record<string, string> = {
   developer: "Java Developer",
@@ -22,6 +23,15 @@ export async function POST(
 
   if (!positionName) {
     return NextResponse.json({ message: "Invalid position" }, { status: 400 });
+  }
+
+  // A position closed in the dashboard must also be closed server-side —
+  // otherwise the form could still be submitted directly.
+  if (!(await isPositionOpen(positionName))) {
+    return NextResponse.json(
+      { message: "Applications for this position are currently closed" },
+      { status: 403 },
+    );
   }
 
   const body = await req.json();

--- a/src/app/apply/builder/page.tsx
+++ b/src/app/apply/builder/page.tsx
@@ -7,6 +7,7 @@ import ApplicationForm, {
 } from "@/components/page/ApplicationForm";
 import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
 import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import { isPositionOpen } from "@/lib/apply";
 
 const META_COPY = {
   en: {
@@ -32,20 +33,6 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-async function isPositionOpen(name: string): Promise<boolean> {
-  try {
-    const res = await fetch("https://cms.onthepixel.net/items/Apply", {
-      next: { revalidate: 60 },
-    });
-    const data = await res.json();
-    const position = (data.data ?? []).find(
-      (p: { name: string; status: string }) => p.name === name,
-    );
-    return position?.status === "open";
-  } catch {
-    return false;
-  }
-}
 
 export default async function BuilderApplicationPage() {
   const [open, { t }] = await Promise.all([

--- a/src/app/apply/developer/page.tsx
+++ b/src/app/apply/developer/page.tsx
@@ -7,6 +7,7 @@ import ApplicationForm, {
 } from "@/components/page/ApplicationForm";
 import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
 import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import { isPositionOpen } from "@/lib/apply";
 
 const META_COPY = {
   en: {
@@ -32,20 +33,6 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-async function isPositionOpen(name: string): Promise<boolean> {
-  try {
-    const res = await fetch("https://cms.onthepixel.net/items/Apply", {
-      next: { revalidate: 60 },
-    });
-    const data = await res.json();
-    const position = (data.data ?? []).find(
-      (p: { name: string; status: string }) => p.name === name,
-    );
-    return position?.status === "open";
-  } catch {
-    return false;
-  }
-}
 
 export default async function DeveloperApplicationPage() {
   const [open, { t }] = await Promise.all([

--- a/src/app/apply/page.tsx
+++ b/src/app/apply/page.tsx
@@ -4,6 +4,7 @@ import TopPage from "@/components/page/top";
 import type { Metadata } from "next";
 import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
 import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import { listApplyPositions, POSITION_ROUTES } from "@/lib/apply";
 
 const META_COPY = {
   en: {
@@ -30,22 +31,9 @@ interface Position {
   name: string;
 }
 
-const POSITION_ROUTES: Record<string, string> = {
-  "Builder": "/apply/builder",
-  "Supporter": "/apply/supporter",
-  "Java Developer": "/apply/developer",
-};
-
 async function getPositions(): Promise<Position[]> {
-  try {
-    const res = await fetch("https://cms.onthepixel.net/items/Apply", {
-      next: { revalidate: 60 },
-    });
-    const data = await res.json();
-    return data.data || [];
-  } catch {
-    return [];
-  }
+  const positions = await listApplyPositions();
+  return positions.map((p) => ({ id: p.id, name: p.name, status: p.status }));
 }
 
 export default async function ApplyPage() {

--- a/src/app/apply/supporter/page.tsx
+++ b/src/app/apply/supporter/page.tsx
@@ -7,6 +7,7 @@ import ApplicationForm, {
 } from "@/components/page/ApplicationForm";
 import { getServerLocale, getServerTranslations } from "@/lib/i18n/server";
 import { buildLocalizedMetadata } from "@/lib/i18n/seo";
+import { isPositionOpen } from "@/lib/apply";
 
 const META_COPY = {
   en: {
@@ -32,20 +33,6 @@ export async function generateMetadata(): Promise<Metadata> {
   });
 }
 
-async function isPositionOpen(name: string): Promise<boolean> {
-  try {
-    const res = await fetch("https://cms.onthepixel.net/items/Apply", {
-      next: { revalidate: 60 },
-    });
-    const data = await res.json();
-    const position = (data.data ?? []).find(
-      (p: { name: string; status: string }) => p.name === name,
-    );
-    return position?.status === "open";
-  } catch {
-    return false;
-  }
-}
 
 export default async function SupporterApplicationPage() {
   const [open, { t }] = await Promise.all([

--- a/src/app/dashboard/apply/apply-dashboard.tsx
+++ b/src/app/dashboard/apply/apply-dashboard.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import React, { useCallback, useEffect, useState } from "react";
+import Link from "next/link";
+import {
+  ClipboardList,
+  RefreshCw,
+  AlertCircle,
+  Loader2,
+  ExternalLink,
+} from "lucide-react";
+import { Switch } from "@/components/ui/switch";
+import AuthGuard from "../auth-guard";
+
+interface Position {
+  id: number;
+  name: string;
+  slug: string;
+  status: "open" | "closed";
+  sortOrder: number;
+}
+
+function PositionCard({
+  position,
+  busy,
+  onToggle,
+}: {
+  position: Position;
+  busy: boolean;
+  onToggle: (next: "open" | "closed") => void;
+}) {
+  const open = position.status === "open";
+
+  return (
+    <div className="flex items-center gap-4 rounded-2xl border border-white/5 bg-white/[0.02] p-5">
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <h2 className="truncate text-base font-semibold text-white">{position.name}</h2>
+          <span
+            className={`rounded-full px-2 py-0.5 text-[11px] font-bold ${
+              open
+                ? "bg-green-500/15 text-green-400"
+                : "bg-white/5 text-white/40"
+            }`}
+          >
+            {open ? "Offen" : "Geschlossen"}
+          </span>
+        </div>
+        <Link
+          href={`/apply/${position.slug}`}
+          target="_blank"
+          className="mt-1 inline-flex items-center gap-1 text-xs text-white/30 transition-colors hover:text-white/60"
+        >
+          /apply/{position.slug} <ExternalLink size={11} />
+        </Link>
+      </div>
+
+      {busy ? (
+        <Loader2 size={18} className="animate-spin text-white/30" />
+      ) : (
+        <Switch
+          checked={open}
+          onCheckedChange={(checked) => onToggle(checked ? "open" : "closed")}
+          aria-label={`Bewerbungen für ${position.name} ${open ? "schließen" : "öffnen"}`}
+        />
+      )}
+    </div>
+  );
+}
+
+function ApplyDashboardContent() {
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [busyId, setBusyId] = useState<number | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/dashboard/apply");
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Fehler ${res.status}`);
+      setPositions(body.data ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setPositions([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  const toggle = async (position: Position, next: "open" | "closed") => {
+    setBusyId(position.id);
+    setError(null);
+    // Optimistic: the switch flips straight away and is rolled back on failure.
+    setPositions((prev) =>
+      prev.map((p) => (p.id === position.id ? { ...p, status: next } : p)),
+    );
+    try {
+      const res = await fetch("/api/dashboard/apply", {
+        method: "PATCH",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id: position.id, status: next }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error(body.error ?? `Fehler ${res.status}`);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+      setPositions((prev) =>
+        prev.map((p) => (p.id === position.id ? { ...p, status: position.status } : p)),
+      );
+    } finally {
+      setBusyId(null);
+    }
+  };
+
+  const openCount = positions.filter((p) => p.status === "open").length;
+
+  return (
+    <div>
+      <div className="mb-6 flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1
+            className="text-2xl font-bold text-white"
+            style={{ fontFamily: "'Syne', sans-serif" }}
+          >
+            Bewerbungen
+          </h1>
+          <p className="mt-0.5 text-sm text-white/40">
+            {openCount} von {positions.length} Positionen offen
+          </p>
+        </div>
+
+        <button
+          onClick={load}
+          disabled={loading}
+          className="flex h-9 items-center gap-2 rounded-lg border border-white/10 bg-white/5 px-3 text-sm text-white/60 transition-colors hover:bg-white/10 hover:text-white disabled:opacity-50"
+        >
+          <RefreshCw size={14} className={loading ? "animate-spin" : ""} />
+          Neu laden
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 flex items-start gap-2 rounded-xl border border-red-500/20 bg-red-500/10 px-4 py-3 text-sm text-red-300">
+          <AlertCircle size={15} className="mt-0.5 shrink-0" />
+          <span>{error}</span>
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex items-center justify-center py-16">
+          <div className="h-8 w-8 animate-spin rounded-full border-2 border-green-400 border-t-transparent" />
+        </div>
+      ) : positions.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-3 rounded-2xl border border-white/5 bg-white/[0.02] py-16">
+          <ClipboardList size={32} className="text-white/10" />
+          <p className="text-sm text-white/30">Keine Positionen gefunden.</p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {positions.map((position) => (
+            <PositionCard
+              key={position.id}
+              position={position}
+              busy={busyId === position.id}
+              onToggle={(next) => toggle(position, next)}
+            />
+          ))}
+        </div>
+      )}
+
+      <p className="mt-6 text-xs text-white/25">
+        Geschlossene Positionen erscheinen auf <code className="text-white/40">/apply</code>{" "}
+        weiterhin, sind aber ausgegraut und nicht verlinkt; das Bewerbungsformular nimmt
+        dann keine Einsendungen mehr an.
+      </p>
+    </div>
+  );
+}
+
+export default function ApplyDashboard() {
+  return (
+    <AuthGuard>
+      <ApplyDashboardContent />
+    </AuthGuard>
+  );
+}

--- a/src/app/dashboard/apply/page.tsx
+++ b/src/app/dashboard/apply/page.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import type { Metadata } from "next";
+import ApplyDashboard from "./apply-dashboard";
+
+export const metadata: Metadata = {
+  title: "Bewerbungen – Admin Dashboard",
+  robots: { index: false },
+};
+
+export default function DashboardApplyPage() {
+  return <ApplyDashboard />;
+}

--- a/src/app/dashboard/layout.tsx
+++ b/src/app/dashboard/layout.tsx
@@ -10,6 +10,7 @@ import {
   Newspaper,
   Users,
   UserCog,
+  ClipboardList,
   LogOut,
   Menu,
   X,
@@ -21,6 +22,7 @@ const navItems = [
   { href: "/dashboard", label: "Overview", icon: LayoutDashboard, exact: true },
   { href: "/dashboard/news", label: "News", icon: Newspaper },
   { href: "/dashboard/creators", label: "Creators", icon: Users },
+  { href: "/dashboard/apply", label: "Bewerbungen", icon: ClipboardList },
   { href: "/dashboard/team", label: "Team", icon: UserCog },
 ];
 

--- a/src/lib/apply.ts
+++ b/src/lib/apply.ts
@@ -1,0 +1,52 @@
+import { asc } from "drizzle-orm";
+import { getDb, schema } from "@/lib/db";
+import { ensureApplyTables } from "@/lib/db/migrate";
+
+export type ApplyStatus = "open" | "closed";
+
+export interface ApplyPosition {
+  id: number;
+  name: string;
+  slug: string;
+  status: ApplyStatus;
+  sortOrder: number;
+}
+
+/** Routes the apply overview links to, keyed by position name. */
+export const POSITION_ROUTES: Record<string, string> = {
+  Builder: "/apply/builder",
+  Supporter: "/apply/supporter",
+  "Java Developer": "/apply/developer",
+};
+
+/**
+ * All positions with their current status. Returns an empty list when the
+ * database is unreachable — the apply pages then simply show nothing open,
+ * which is the safe direction to fail in.
+ */
+export async function listApplyPositions(): Promise<ApplyPosition[]> {
+  try {
+    await ensureApplyTables();
+    const rows = await getDb()
+      .select()
+      .from(schema.applyPositions)
+      .orderBy(asc(schema.applyPositions.sort_order), asc(schema.applyPositions.id));
+
+    return rows.map((row) => ({
+      id: row.id,
+      name: row.name,
+      slug: row.slug,
+      status: row.status === "open" ? "open" : "closed",
+      sortOrder: row.sort_order,
+    }));
+  } catch (e) {
+    console.error("[apply] database read failed:", e);
+    return [];
+  }
+}
+
+/** Whether applications for a position are currently accepted. */
+export async function isPositionOpen(name: string): Promise<boolean> {
+  const positions = await listApplyPositions();
+  return positions.some((p) => p.name === name && p.status === "open");
+}

--- a/src/lib/db/migrate.ts
+++ b/src/lib/db/migrate.ts
@@ -3,6 +3,18 @@ import { sql } from "drizzle-orm";
 
 let initialized = false;
 let creatorsInitialized = false;
+let applyInitialized = false;
+
+/**
+ * The positions the apply pages offer. They are seeded on first use so the
+ * dashboard has something to toggle; the seed is `closed` so a position never
+ * opens itself without an admin saying so.
+ */
+export const APPLY_POSITION_SEED = [
+  { name: "Builder", slug: "builder" },
+  { name: "Supporter", slug: "supporter" },
+  { name: "Java Developer", slug: "developer" },
+] as const;
 
 export async function ensureTable() {
   if (initialized) return;
@@ -73,6 +85,35 @@ export async function ensureCreatorTables() {
     creatorsInitialized = true;
   } catch (e) {
     console.error("[db] ensureCreatorTables failed:", e);
+    throw e;
+  }
+}
+
+export async function ensureApplyTables() {
+  if (applyInitialized) return;
+  const db = getDb();
+  try {
+    await db.execute(sql`
+      CREATE TABLE IF NOT EXISTS apply_positions (
+        id SERIAL PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        slug TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL DEFAULT 'closed',
+        sort_order INTEGER NOT NULL DEFAULT 0,
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `);
+    for (let i = 0; i < APPLY_POSITION_SEED.length; i++) {
+      const { name, slug } = APPLY_POSITION_SEED[i];
+      await db.execute(sql`
+        INSERT INTO apply_positions (name, slug, status, sort_order)
+        VALUES (${name}, ${slug}, 'closed', ${i})
+        ON CONFLICT (name) DO NOTHING
+      `);
+    }
+    applyInitialized = true;
+  } catch (e) {
+    console.error("[db] ensureApplyTables failed:", e);
     throw e;
   }
 }

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -39,9 +39,19 @@ export const creatorChannels = pgTable("creator_channels", {
   sort_order: integer("sort_order").notNull().default(0),
 });
 
+export const applyPositions = pgTable("apply_positions", {
+  id: serial("id").primaryKey(),
+  name: text("name").notNull().unique(),
+  slug: text("slug").notNull().unique(),
+  status: text("status").notNull().default("closed"),
+  sort_order: integer("sort_order").notNull().default(0),
+  updated_at: timestamp("updated_at", { withTimezone: true }).defaultNow().notNull(),
+});
+
 export type NewsItem = typeof news.$inferSelect;
 export type NewNewsItem = typeof news.$inferInsert;
 export type NewsTranslationItem = typeof newsTranslations.$inferSelect;
 export type CreatorRecord = typeof creators.$inferSelect;
 export type NewCreatorRecord = typeof creators.$inferInsert;
 export type CreatorChannelRecord = typeof creatorChannels.$inferSelect;
+export type ApplyPositionRecord = typeof applyPositions.$inferSelect;


### PR DESCRIPTION
Zwei Schritte weiter Richtung CMS-Abschaltung: der Bewerbungsstatus wandert ins Dashboard, und die bestehenden Creators lassen sich mit einem Skript aus dem CMS übernehmen.

## Bewerbungen im Dashboard (`/dashboard/apply`)

Ob eine Position offen oder geschlossen ist, stand bisher im Directus-CMS. Der Status liegt jetzt in Postgres und wird per Schalter umgestellt.

- Tabelle `apply_positions` (Name, Slug, Status, Reihenfolge), die beim ersten Zugriff mit Builder, Supporter und Java Developer befüllt wird
- **Der Seed steht auf `closed`** — nach dem Deploy sind alle Positionen zunächst geschlossen und müssen im Dashboard geöffnet werden. So öffnet sich keine Position ungewollt von selbst.
- Schalter je Position mit optimistischem Update; schlägt das Speichern fehl, springt der Schalter zurück und der Fehler wird angezeigt
- `/apply` und die drei Formularseiten lesen den Status aus der Datenbank statt aus dem CMS

Zusätzlich: Die Submit-Route `/apply/api/:position` lehnt Bewerbungen auf geschlossene Positionen jetzt auch **serverseitig mit 403** ab. Bisher wurde nur die Seite ausgegraut — ein direkter POST wäre durchgegangen.

| Request | Ergebnis |
| --- | --- |
| `GET /api/apply` | alle Positionen (öffentlich, CMS-Format `id`/`name`/`status` plus `slug`) |
| `GET /api/apply?slug=builder` | einzelne Position |
| `GET/PATCH /api/dashboard/apply` | lesen / Status setzen (auth-geschützt) |

## Creator-Import aus dem CMS

```
DATABASE_URL=… node scripts/import-creators.mjs           # Vorschau, schreibt nichts
DATABASE_URL=… node scripts/import-creators.mjs --write    # übernimmt die Daten
```

Reines Node-Skript ohne Build-Schritt, nutzt den vorhandenen `postgres`-Treiber. Optionen: `--cms-url=`, `--skip-existing`.

Das CMS speichert unter `Minecraft_username` einen **Spielernamen**, die neue Tabelle braucht aber eine **UUID** — die Namen werden deshalb gebündelt über die Mojang-API aufgelöst (10 pro Anfrage, Einzelabfrage als Rückfallebene). Creators ohne auflösbare UUID werden übersprungen und namentlich gemeldet, statt den Lauf abzubrechen.

Der Lauf ist wiederholbar: vorhandene UUIDs werden aktualisiert und ihre Kanäle ersetzt, es entstehen keine Duplikate. Die Reihenfolge der Platforms bleibt erhalten, `Platform[0]` bleibt der primäre Kanal.

## Tests

Gegen echtes Postgres geprüft:

- Seed legt die drei Positionen als `closed` an; `GET /api/apply` und `?slug=` liefern sie, unbekannter Slug ergibt 404
- `GET` und `PATCH` auf `/api/dashboard/apply` ohne Session ergeben 401
- Auf `/apply` ist ausschließlich die offene Position verlinkt; nach dem Schließen bleibt kein Link übrig
- Import gegen eine nachgebaute CMS-Antwort: Dry-Run schreibt nichts (auch nicht die Tabellen), Schreiblauf legt Creators mit korrekter Kanal-Reihenfolge an, zweiter Lauf aktualisiert ohne Duplikate, `--skip-existing` lässt alles unverändert
- Ungültige Kanal-URLs werden verworfen, leere Plattform wird zu `website`, fehlende `DATABASE_URL` und ein nicht erreichbares CMS brechen mit klarer Meldung ab

Dabei ist ein echter Fehler aufgefallen und behoben: der Dry-Run stürzte auf einer frischen Datenbank ab, weil er `creators` abfragte, bevor die Tabelle existierte.

`npm run typecheck` und `npm run build` laufen sauber durch.

## Hinweise

- CMS und Mojang-API sind aus der Build-Umgebung nicht erreichbar (nur IPv6), der Import wurde deshalb gegen eine nachgebaute CMS-Antwort getestet und muss dort laufen, wo das CMS erreichbar ist.
- Nach diesem PR nutzt nur noch `/sidequests` das CMS.

---
_Generated by [Claude Code](https://claude.ai/code/session_016vqoSTpv1rPPqC6qgCaFWB)_